### PR TITLE
rename imports and go module database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
     description: build with Darwin
     macos:
       xcode: "10.0.0"
-    working_directory: ~/go/src/github.com/filecoin-project/go-storage-mining
+    working_directory: ~/go/src/github.com/filecoin-project/go-storage-miner
     steps:
       - prepare:
           linux: false
@@ -112,7 +112,7 @@ jobs:
             chmod +x $HOME/.bin/jq
       - restore_cache:
           name: restore go mod and cargo cache
-          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/go-storage-mining/go.sum" }}
+          key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/go-storage-miner/go.sum" }}
       - install-deps
       - go/mod-download
       - run:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/filecoin-project/go-storage-mining
+module github.com/filecoin-project/go-storage-miner
 
 go 1.13
 

--- a/storage/sectors.go
+++ b/storage/sectors.go
@@ -9,7 +9,7 @@ import (
 	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
 	xerrors "golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-storage-mining/lib/padreader"
+	"github.com/filecoin-project/go-storage-miner/lib/padreader"
 )
 
 const NonceIncrement = math.MaxUint64

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 
-	"github.com/filecoin-project/go-storage-mining/storage"
+	"github.com/filecoin-project/go-storage-miner/storage"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	mh "github.com/multiformats/go-multihash"

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 
-	"github.com/filecoin-project/go-storage-mining/storage"
+	"github.com/filecoin-project/go-storage-miner/storage"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/sector_state_tracker.go
+++ b/test/sector_state_tracker.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-storage-mining/storage"
+	"github.com/filecoin-project/go-storage-miner/storage"
 
 	"gotest.tools/assert"
 )


### PR DESCRIPTION
## What's in this PR?

We renamed the GitHub project, so we're stuck renaming all the imports.

