### PR TITLE
ensure jq is available on CircleCI path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,8 @@ jobs:
       - run:
           name: Install jq
           command: |
-            mkdir $HOME/.bin
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output $HOME/.bin/jq
-            chmod +x $HOME/.bin/jq
+            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output /usr/local/bin/jq
+            chmod +x /usr/local/bin/jq
       - restore_cache:
           name: restore go mod and cargo cache
           key: v1-go-deps-{{ arch }}-{{ checksum "~/go/src/github.com/filecoin-project/go-storage-mining/go.sum" }}


### PR DESCRIPTION
## Why does this PR exist?

The filecoin-ffi build tooling requires `jq` to parse GitHub releases JSON output in order to get the asset URLs.

## What's in this PR?

This PR modifies the CircleCI build config to install jq to a known path.