### PR TITLE
use channels in and rename GetSealSeed

### DIFF
--- a/node_api.go
+++ b/node_api.go
@@ -30,9 +30,8 @@ type NodeAPI interface {
 	// when they start encoding a sector.
 	GetSealTicket(context.Context) (SealTicket, error)
 
-	// GetSealSeed sets the seal seed handler associated with the
-	// provided pre-commit message. Any handler previously associated with the
-	// provided pre-commit message is replaced.
+	// GetSealSeed requests that a seal seed be provided through the return channel the given block interval after the preCommitMsg arrives on chain.
+	// It expects to be notified through the invalidated channel if a re-org sets the chain back to before the height at the interval.
 	GetSealSeed(ctx context.Context, preCommitMsg cid.Cid, interval uint64) (seed <-chan SealSeed, err <-chan error, invalidated <-chan struct{}, done <-chan struct{})
 }
 

--- a/node_api.go
+++ b/node_api.go
@@ -30,10 +30,10 @@ type NodeAPI interface {
 	// when they start encoding a sector.
 	GetSealTicket(context.Context) (SealTicket, error)
 
-	// SetSealSeedHandler sets the seal seed handler associated with the
+	// GetSealSeed sets the seal seed handler associated with the
 	// provided pre-commit message. Any handler previously associated with the
 	// provided pre-commit message is replaced.
-	SetSealSeedHandler(ctx context.Context, preCommitMsg cid.Cid, seedAvailFunc func(SealSeed), seedInvalidatedFunc func())
+	GetSealSeed(ctx context.Context, preCommitMsg cid.Cid, interval uint64) (seed <-chan SealSeed, err <-chan error, invalidated <-chan struct{}, done <-chan struct{})
 }
 
 type PieceInfo struct {

--- a/sectors.go
+++ b/sectors.go
@@ -13,6 +13,7 @@ import (
 )
 
 const NonceIncrement = math.MaxUint64
+const InteractivePoRepDelay = 8
 
 type sectorUpdate struct {
 	newState SectorState

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -275,7 +275,7 @@ func TestHandlesCommitSectorMessageNeverIncludedInBlock(t *testing.T) {
 }
 
 func TestSealSeedInvalidated(t *testing.T) {
-	// SetSealSeedHandler called our "seed available" handler, and then some
+	// GetSealSeed called our "seed available" handler, and then some
 	// time later called our "seed invalidated" handler
 	t.Skip("the sector should go back to a PreCommitted state")
 }


### PR DESCRIPTION
### What is in this PR

Rename `SetSealSeedHandler` to `GetSealSeed` and change its signature to return channels rather than using callbacks (that don't support error handling).