### PR TITLE
drop unused method and unused block height (from return tuple)

### DIFF
--- a/node_api.go
+++ b/node_api.go
@@ -18,8 +18,6 @@ type NodeAPI interface {
 	// particular chain and returns the identity of the corresponding message.
 	SendPreCommitSector(ctx context.Context, sectorID uint64, commR []byte, ticket SealTicket, pieces ...Piece) (cid.Cid, error)
 
-	WaitForPreCommitSector(context.Context, cid.Cid) (uint64, uint8, error)
-
 	// SendProveCommitSector publishes the miner's seal proof and returns the
 	// the identity of the corresponding message.
 	SendProveCommitSector(ctx context.Context, sectorID uint64, proof []byte, dealids ...uint64) (cid.Cid, error)

--- a/node_api.go
+++ b/node_api.go
@@ -24,7 +24,7 @@ type NodeAPI interface {
 
 	// WaitForProveCommitSector blocks until the provided message is mined into
 	// a block.
-	WaitForProveCommitSector(context.Context, cid.Cid) (uint64, uint8, error)
+	WaitForProveCommitSector(context.Context, cid.Cid) (uint8, error)
 
 	// SendReportFaults reports sectors as faulty.
 	SendReportFaults(ctx context.Context, sectorIDs ...uint64) (cid.Cid, error)

--- a/states.go
+++ b/states.go
@@ -146,7 +146,7 @@ func (m *Sealing) handleCommitWait(ctx statemachine.Context, sector SectorInfo) 
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("entered commit wait with no commit cid")})
 	}
 
-	_, exitCode, err := m.api.WaitForProveCommitSector(ctx.Context(), *sector.CommitMessage)
+	exitCode, err := m.api.WaitForProveCommitSector(ctx.Context(), *sector.CommitMessage)
 	if err != nil {
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("failed to wait for porep inclusion: %w", err)})
 	}

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -14,7 +14,6 @@ type fakeNode struct {
 	sendSelfDeals            func(context.Context, ...storage.PieceInfo) (cid.Cid, error)
 	waitForSelfDeals         func(context.Context, cid.Cid) (dealIds []uint64, exitCode uint8, err error)
 	sendPreCommitSector      func(ctx context.Context, sectorID uint64, commR []byte, ticket storage.SealTicket, pieces ...storage.Piece) (cid.Cid, error)
-	waitForPreCommitSector   func(context.Context, cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error)
 	sendProveCommitSector    func(ctx context.Context, sectorID uint64, proof []byte, dealIds ...uint64) (cid.Cid, error)
 	waitForProveCommitSector func(context.Context, cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error)
 	getSealTicket            func(context.Context) (storage.SealTicket, error)
@@ -36,9 +35,6 @@ func newFakeNode() *fakeNode {
 		},
 		sendPreCommitSector: func(ctx context.Context, sectorID uint64, commR []byte, ticket storage.SealTicket, pieces ...storage.Piece) (cid.Cid, error) {
 			return createCidForTesting(42), nil
-		},
-		waitForPreCommitSector: func(context.Context, cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error) {
-			return 42, 0, nil
 		},
 		sendProveCommitSector: func(ctx context.Context, sectorID uint64, proof []byte, dealIds ...uint64) (cid.Cid, error) {
 			return createCidForTesting(42), nil
@@ -91,10 +87,6 @@ func (f *fakeNode) WaitForSelfDeals(ctx context.Context, msg cid.Cid) (dealIds [
 
 func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorID uint64, commR []byte, ticket storage.SealTicket, pieces ...storage.Piece) (cid.Cid, error) {
 	return f.sendPreCommitSector(ctx, sectorID, commR, ticket, pieces...)
-}
-
-func (f *fakeNode) WaitForPreCommitSector(ctx context.Context, msg cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error) {
-	return f.waitForPreCommitSector(ctx, msg)
 }
 
 func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorID uint64, proof []byte, dealIds ...uint64) (cid.Cid, error) {

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -15,7 +15,7 @@ type fakeNode struct {
 	waitForSelfDeals         func(context.Context, cid.Cid) (dealIds []uint64, exitCode uint8, err error)
 	sendPreCommitSector      func(ctx context.Context, sectorID uint64, commR []byte, ticket storage.SealTicket, pieces ...storage.Piece) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorID uint64, proof []byte, dealIds ...uint64) (cid.Cid, error)
-	waitForProveCommitSector func(context.Context, cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error)
+	waitForProveCommitSector func(context.Context, cid.Cid) (exitCode uint8, err error)
 	getSealTicket            func(context.Context) (storage.SealTicket, error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan storage.SealSeed, <-chan error, <-chan struct{}, <-chan struct{})
 	checkPieces              func(ctx context.Context, sectorID uint64, pieces []storage.Piece) *storage.CheckPiecesError
@@ -39,8 +39,8 @@ func newFakeNode() *fakeNode {
 		sendProveCommitSector: func(ctx context.Context, sectorID uint64, proof []byte, dealIds ...uint64) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
-		waitForProveCommitSector: func(context.Context, cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error) {
-			return 42, 0, nil
+		waitForProveCommitSector: func(context.Context, cid.Cid) (exitCode uint8, err error) {
+			return 0, nil
 		},
 		getSealTicket: func(context.Context) (storage.SealTicket, error) {
 			return storage.SealTicket{
@@ -93,7 +93,7 @@ func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorID uint64, p
 	return f.sendProveCommitSector(ctx, sectorID, proof, dealIds...)
 }
 
-func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (processedAtBlockHeight uint64, exitCode uint8, err error) {
+func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (exitCode uint8, err error) {
 	return f.waitForProveCommitSector(ctx, msg)
 }
 

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -209,8 +209,8 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
 
-		n.waitForProveCommitSector = func(i context.Context, i2 cid.Cid) (uint64, uint8, error) {
-			return 0, 0, errors.New("expected behavior")
+		n.waitForProveCommitSector = func(i context.Context, i2 cid.Cid) (uint8, error) {
+			return 0, errors.New("expected behavior")
 		}
 
 		return n


### PR DESCRIPTION
## What's in this PR?

- drop the now-unused `WaitForPreCommitSector` method (waiting for pre-commit sector message happens as part of `GetSealSeed`)
- drop the never-used "mined at block height" return value from `WaitForProveCommitSector`