### PR TITLE
CheckSealing needs the ticket in order to do its job

### DIFF
--- a/node_api.go
+++ b/node_api.go
@@ -57,7 +57,7 @@ type NodeAPI interface {
 	// commitment of the given pieces associated with the given deals. The
 	// ordering of the deals must match the ordering of the related pieces in
 	// the sector.
-	CheckSealing(ctx context.Context, commD []byte, dealIDs []uint64) *CheckSealingError
+	CheckSealing(ctx context.Context, commD []byte, dealIDs []uint64, ticket SealTicket) *CheckSealingError
 }
 
 type PieceInfo struct {

--- a/states.go
+++ b/states.go
@@ -76,7 +76,7 @@ func (m *Sealing) handleUnsealed(ctx statemachine.Context, sector SectorInfo) er
 }
 
 func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInfo) error {
-	if err := m.api.CheckSealing(ctx.Context(), sector.CommD, sector.deals()); err != nil {
+	if err := m.api.CheckSealing(ctx.Context(), sector.CommD, sector.deals(), sector.Ticket); err != nil {
 		switch err.EType {
 		case CheckSealingAPI:
 			log.Errorf("handlePreCommitting: api error, not proceeding: %+v", err)

--- a/states_failed.go
+++ b/states_failed.go
@@ -54,7 +54,7 @@ func (m *Sealing) handleSealFailed(ctx statemachine.Context, sector SectorInfo) 
 }
 
 func (m *Sealing) handlePreCommitFailed(ctx statemachine.Context, sector SectorInfo) error {
-	if err := m.api.CheckSealing(ctx.Context(), sector.CommD, sector.deals()); err != nil {
+	if err := m.api.CheckSealing(ctx.Context(), sector.CommD, sector.deals(), sector.Ticket); err != nil {
 		switch err.EType {
 		case CheckSealingAPI:
 			log.Errorf("handlePreCommitFailed: api error, not proceeding: %+v", err)


### PR DESCRIPTION
In order to check that the ticket is not expired, we need to pass the ticket into the `CheckSeal` operation.