### PR TITLE
various edits to conform to lotus Miner interface

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -233,6 +233,7 @@ func (m *Sealing) restartSectors(ctx context.Context) error {
 	return nil
 }
 
+// ForceSectorState puts a sector with given ID into the given state.
 func (m *Sealing) ForceSectorState(ctx context.Context, id uint64, state SectorState) error {
 	return m.sectors.Send(id, SectorForceState{state})
 }

--- a/miner.go
+++ b/miner.go
@@ -121,7 +121,5 @@ func (m *Miner) SealPiece(ctx context.Context, size uint64, r io.Reader, sectorI
 // behavior to call this method more than once. It is undefined behavior to call
 // this method concurrently with any other Miner method.
 func (m *Miner) Stop(ctx context.Context) error {
-	defer m.sealing.Stop(ctx) // nolint: errcheck
-
-	return nil
+	return m.sealing.Stop(ctx)
 }

--- a/miner.go
+++ b/miner.go
@@ -55,22 +55,14 @@ func NewMinerWithOnSectorUpdated(api NodeAPI, ds datastore.Batching, sb SectorBu
 	}, nil
 }
 
-func (m *Miner) Start(ctx context.Context) error {
-	if m.onSectorUpdated != nil {
-		m.sealing = NewWithOnSectorUpdated(m.api, m.sb, m.ds, m.worker, m.maddr, m.onSectorUpdated)
-	} else {
-		m.sealing = New(m.api, m.sb, m.ds, m.worker, m.maddr)
-	}
-
-	go m.sealing.Run(ctx) // nolint: errcheck
-
-	return nil
-}
-
-func (m *Miner) Stop(ctx context.Context) error {
-	defer m.sealing.Stop(ctx) // nolint: errcheck
-
-	return nil
+// AllocatePiece produces information about where a piece of a given size can
+// be written.
+//
+// TODO: This signature doesn't make much sense. Returning a sector ID here
+// means that we won't have the ability to move the piece around (i.e. do
+// intelligent bin packing) after allocating. -- @laser
+func (m *Miner) AllocatePiece(size uint64) (sectorID uint64, offset uint64, err error) {
+	return m.sealing.AllocatePiece(size)
 }
 
 // AllocateSectorID allocates a new sector ID.
@@ -78,16 +70,9 @@ func (m *Miner) AllocateSectorID() (sectorID uint64, err error) {
 	return m.sb.AcquireSectorId()
 }
 
-// PledgeSector allocates a new sector, fills it with self-deal junk, and
-// seals that sector.
-func (m *Miner) PledgeSector() error {
-	return m.sealing.PledgeSector()
-}
-
-// SealPiece writes the provided piece to a newly-created sector which it
-// immediately seals.
-func (m *Miner) SealPiece(ctx context.Context, size uint64, r io.Reader, sectorID uint64, dealID uint64) error {
-	return m.sealing.SealPiece(ctx, size, r, sectorID, dealID)
+// ForceSectorState puts a sector with given ID into the given state.
+func (m *Miner) ForceSectorState(ctx context.Context, id uint64, state SectorState) error {
+	return m.sealing.ForceSectorState(ctx, id, state)
 }
 
 // GetSectorInfo produces information about a sector managed by this storage
@@ -101,4 +86,42 @@ func (m *Miner) GetSectorInfo(sectorID uint64) (SectorInfo, error) {
 // or otherwise).
 func (m *Miner) ListSectors() ([]SectorInfo, error) {
 	return m.sealing.ListSectors()
+}
+
+// PledgeSector allocates a new sector, fills it with self-deal junk, and
+// seals that sector.
+func (m *Miner) PledgeSector() error {
+	return m.sealing.PledgeSector()
+}
+
+// Run starts the Miner, which causes it (and its collaborating objects) to
+// start listening for sector state-transitions. It is undefined behavior to
+// call this method more than once. It is undefined behavior to call this method
+// concurrently with any other Miner method.
+func (m *Miner) Run(ctx context.Context) error {
+	if m.onSectorUpdated != nil {
+		m.sealing = NewWithOnSectorUpdated(m.api, m.sb, m.ds, m.worker, m.maddr, m.onSectorUpdated)
+	} else {
+		m.sealing = New(m.api, m.sb, m.ds, m.worker, m.maddr)
+	}
+
+	go m.sealing.Run(ctx) // nolint: errcheck
+
+	return nil
+}
+
+// SealPiece writes the provided piece to a newly-created sector which it
+// immediately seals.
+func (m *Miner) SealPiece(ctx context.Context, size uint64, r io.Reader, sectorID uint64, dealID uint64) error {
+	return m.sealing.SealPiece(ctx, size, r, sectorID, dealID)
+}
+
+// Stop causes the miner to stop listening for sector state transitions. It is
+// undefined behavior to call this method before calling Start. It is undefined
+// behavior to call this method more than once. It is undefined behavior to call
+// this method concurrently with any other Miner method.
+func (m *Miner) Stop(ctx context.Context) error {
+	defer m.sealing.Stop(ctx) // nolint: errcheck
+
+	return nil
 }

--- a/sealing.go
+++ b/sealing.go
@@ -70,6 +70,20 @@ func (m *Sealing) Stop(ctx context.Context) error {
 	return m.sectors.Stop(ctx)
 }
 
+func (m *Sealing) AllocatePiece(size uint64) (sectorID uint64, offset uint64, err error) {
+	if padreader.PaddedSize(size) != size {
+		return 0, 0, xerrors.Errorf("cannot allocate unpadded piece")
+	}
+
+	sid, err := m.sb.AcquireSectorId() // TODO: Put more than one thing in a sector
+	if err != nil {
+		return 0, 0, xerrors.Errorf("acquiring sector ID: %w", err)
+	}
+
+	// offset hard-coded to 0 since we only put one thing in a sector for now
+	return sid, 0, nil
+}
+
 func (m *Sealing) SealPiece(ctx context.Context, size uint64, r io.Reader, sectorID uint64, dealID uint64) error {
 	if padreader.PaddedSize(size) != size {
 		return xerrors.Errorf("cannot seal unpadded piece")

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -42,7 +42,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 	}()
 
 	// start the internal runloop
-	require.NoError(t, miner.Start(ctx))
+	require.NoError(t, miner.Run(ctx))
 
 	// kick off the state machine
 	require.NoError(t, miner.SealPiece(ctx, UserBytesOneKiBSector, io.LimitReader(rand.New(rand.NewSource(42)), int64(UserBytesOneKiBSector)), DefaultSectorID, DefaultDealID))
@@ -107,7 +107,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 	pieceReader := io.LimitReader(rand.New(rand.NewSource(42)), int64(pieceSize))
 
 	// kick off state transitions
-	require.NoError(t, miner.Start(ctx))
+	require.NoError(t, miner.Run(ctx))
 	require.NoError(t, miner.SealPiece(ctx, pieceSize, pieceReader, sectorID, DefaultDealID))
 
 	select {
@@ -149,7 +149,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 	}()
 
 	// kick off state transitions
-	require.NoError(t, miner.Start(ctx))
+	require.NoError(t, miner.Run(ctx))
 	require.NoError(t, miner.SealPiece(ctx, UserBytesOneKiBSector, io.LimitReader(rand.New(rand.NewSource(42)), int64(UserBytesOneKiBSector)), DefaultSectorID, DefaultDealID))
 
 	select {
@@ -191,7 +191,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 	}()
 
 	// kick off state transitions
-	require.NoError(t, miner.Start(ctx))
+	require.NoError(t, miner.Run(ctx))
 	require.NoError(t, miner.SealPiece(ctx, UserBytesOneKiBSector, io.LimitReader(rand.New(rand.NewSource(42)), int64(UserBytesOneKiBSector)), DefaultSectorID, DefaultDealID))
 
 	select {
@@ -234,7 +234,7 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 	}()
 
 	// kick off state transitions
-	require.NoError(t, miner.Start(ctx))
+	require.NoError(t, miner.Run(ctx))
 	require.NoError(t, miner.SealPiece(ctx, UserBytesOneKiBSector, io.LimitReader(rand.New(rand.NewSource(42)), int64(UserBytesOneKiBSector)), DefaultSectorID, DefaultDealID))
 
 	select {


### PR DESCRIPTION
## Why does this PR exist?

In order for this code to be consumed by lotus, it needs to provide the same interface as the lotus `Miner` struct. This includes things like `ForceSectorState` and `AllocatePiece`.

## What's in this PR?

- add a few methods to `Miner` which delegate to `Sealing` in the same way that the lotus `Miner` does
- rename `Start` to `Run` to match lotus