### PR TITLE
consume new lotus changes

### DIFF
--- a/fsm_events.go
+++ b/fsm_events.go
@@ -118,6 +118,14 @@ type SectorProving struct{}
 
 func (evt SectorProving) apply(*SectorInfo) {}
 
+type SectorFinalized struct{}
+
+func (evt SectorFinalized) apply(*SectorInfo) {}
+
+type SectorFinalizeFailed struct{ error }
+
+func (evt SectorFinalizeFailed) apply(*SectorInfo) {}
+
 // Failed state recovery
 
 type SectorRetrySeal struct{}

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -48,6 +48,9 @@ func TestHappyPath(t *testing.T) {
 	require.Equal(m.t, m.state.State, CommitWait)
 
 	m.planSingle(SectorProving{})
+	require.Equal(m.t, m.state.State, FinalizeSector)
+
+	m.planSingle(SectorFinalized{})
 	require.Equal(m.t, m.state.State, Proving)
 }
 
@@ -79,5 +82,22 @@ func TestSeedRevert(t *testing.T) {
 	require.Equal(m.t, m.state.State, CommitWait)
 
 	m.planSingle(SectorProving{})
+	require.Equal(m.t, m.state.State, FinalizeSector)
+
+	m.planSingle(SectorFinalized{})
 	require.Equal(m.t, m.state.State, Proving)
+}
+
+func TestPlanCommittingHandlesSectorCommitFailed(t *testing.T) {
+	m := test{
+		s:     &Sealing{},
+		t:     t,
+		state: &SectorInfo{State: Committing},
+	}
+
+	events := []statemachine.Event{{SectorCommitFailed{}}}
+
+	require.NoError(t, planCommitting(events, m.state))
+
+	require.Equal(t, SectorStates[CommitFailed], SectorStates[m.state.State])
 }

--- a/garbage.go
+++ b/garbage.go
@@ -3,23 +3,40 @@ package storage
 import (
 	"context"
 	"io"
+	"math/bits"
 	"math/rand"
+	"runtime"
 
-	"github.com/filecoin-project/go-sectorbuilder"
+	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
 	"golang.org/x/xerrors"
 )
+
+func (m *Sealing) pledgeReader(size uint64, parts uint64) io.Reader {
+	parts = 1 << bits.Len64(parts) // round down to nearest power of 2
+	if size/parts < 127 {
+		parts = size / 127
+	}
+
+	piece := sectorbuilder.UserBytesForSectorSize((size/127 + size) / parts)
+
+	readers := make([]io.Reader, parts)
+	for i := range readers {
+		readers[i] = io.LimitReader(rand.New(rand.NewSource(42+int64(i))), int64(piece))
+	}
+
+	return io.MultiReader(readers...)
+}
 
 func (m *Sealing) pledgeSector(ctx context.Context, sectorID uint64, existingPieceSizes []uint64, sizes ...uint64) ([]Piece, error) {
 	if len(sizes) == 0 {
 		return nil, nil
 	}
 
+	log.Infof("Pledge %d, contains %+v", sectorID, existingPieceSizes)
+
 	pieces := make([]PieceInfo, len(sizes))
 	for i, size := range sizes {
-		release := m.sb.RateLimit()
-		commP, err := sectorbuilder.GeneratePieceCommitment(io.LimitReader(rand.New(rand.NewSource(42)), int64(size)), size)
-		release()
-
+		commP, err := m.fastPledgeCommitment(size, uint64(runtime.NumCPU()))
 		if err != nil {
 			return nil, err
 		}
@@ -29,6 +46,8 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID uint64, existingPie
 			CommP: commP,
 		}
 	}
+
+	log.Infof("Publishing deals for %d", sectorID)
 
 	mcid, err := m.api.SendSelfDeals(ctx, pieces...)
 	if err != nil {
@@ -55,9 +74,9 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID uint64, existingPie
 	out := make([]Piece, len(sizes))
 
 	for i, size := range sizes {
-		ppi, err := m.sb.AddPiece(ctx, size, sectorID, io.LimitReader(rand.New(rand.NewSource(42)), int64(size)), existingPieceSizes)
+		ppi, err := m.sb.AddPiece(ctx, size, sectorID, m.pledgeReader(size, uint64(runtime.NumCPU())), existingPieceSizes)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("add piece: %w", err)
 		}
 
 		existingPieceSizes = append(existingPieceSizes, size)
@@ -97,6 +116,5 @@ func (m *Sealing) PledgeSector() error {
 			return
 		}
 	}()
-
 	return nil
 }

--- a/garbage.go
+++ b/garbage.go
@@ -55,7 +55,7 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID uint64, existingPie
 	out := make([]Piece, len(sizes))
 
 	for i, size := range sizes {
-		ppi, err := m.sb.AddPiece(size, sectorID, io.LimitReader(rand.New(rand.NewSource(42)), int64(size)), existingPieceSizes)
+		ppi, err := m.sb.AddPiece(ctx, size, sectorID, io.LimitReader(rand.New(rand.NewSource(42)), int64(size)), existingPieceSizes)
 		if err != nil {
 			return nil, err
 		}

--- a/garbage.go
+++ b/garbage.go
@@ -36,7 +36,7 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorID uint64, existingPie
 
 	pieces := make([]PieceInfo, len(sizes))
 	for i, size := range sizes {
-		commP, err := m.fastPledgeCommitment(size, uint64(runtime.NumCPU()))
+		commP, err := m.FastPledgeCommitment(size, uint64(runtime.NumCPU()))
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.13
 
 require (
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
-	github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f
+	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-padreader v0.0.0-20200129213049-ea73e2aaabd1
-	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689
+	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c
 	github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c
 	github.com/ipfs/go-cid v0.0.4
 	github.com/ipfs/go-datastore v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/filecoin-project/go-padreader v0.0.0-20200129213049-ea73e2aaabd1
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c
 	github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-cid v0.0.4
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-ipld-cbor v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-	gotest.tools v2.2.0+incompatible
 )
 
 replace github.com/golangci/golangci-lint => github.com/golangci/golangci-lint v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,10 @@ github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f h1:KMlcu9X58lhTA
 github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f h1:L2jaVU8TvWTx7iZPhlYvUE8vkoOnj778XuKavz8W36g=
 github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f/go.mod h1:rCbpXPva2NKF9/J4X6sr7hbKBgQCxyFtRj7KOZqoIms=
+github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
+github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
@@ -27,6 +29,8 @@ github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689 h1:2cT5bhm/5I0RY+HBIPdRRrtjCwLj33Qx6DHRs9TCslY=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689/go.mod h1:3OZ4E3B2OuwhJjtxR4r7hPU9bCfB+A+hm4alLEsaeDc=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c h1:qv1tEab/IklFknEM8VK2WgxxM7aZ5/uwm5xFgvHTp4A=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c/go.mod h1:jNGVCDihkMFnraYVLH1xl4ceZQVxx/u4dOORrTKeRi0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c h1:VF+CVDsAzY6PPuKteJSKtHJpkQMCHf1oKQw8LFW/0w8=
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c/go.mod h1:1K7s8n65xznskrVYhwalQDO5blLMIZlf96OYQilZVJY=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f h1:L2jaVU8TvWTx7iZPhlYvUE8vkoOnj778XuKavz8W36g=
-github.com/filecoin-project/go-address v0.0.0-20191219011437-af739c490b4f/go.mod h1:rCbpXPva2NKF9/J4X6sr7hbKBgQCxyFtRj7KOZqoIms=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
@@ -27,8 +25,6 @@ github.com/filecoin-project/go-padreader v0.0.0-20200129213049-ea73e2aaabd1 h1:x
 github.com/filecoin-project/go-padreader v0.0.0-20200129213049-ea73e2aaabd1/go.mod h1:Bu34RWAifHqV29tAx4S8TxMa7h42fkLlXAQUl29DNQs=
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:YicJT9xhPzZ1SBGiJFNUCkfwqK/G9vFyY1ytKBSjNJA=
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689 h1:2cT5bhm/5I0RY+HBIPdRRrtjCwLj33Qx6DHRs9TCslY=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200114015900-4103afa82689/go.mod h1:3OZ4E3B2OuwhJjtxR4r7hPU9bCfB+A+hm4alLEsaeDc=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c h1:qv1tEab/IklFknEM8VK2WgxxM7aZ5/uwm5xFgvHTp4A=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200131010043-6b57024f839c/go.mod h1:jNGVCDihkMFnraYVLH1xl4ceZQVxx/u4dOORrTKeRi0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200129214539-c78c5f7e9f9c h1:VF+CVDsAzY6PPuKteJSKtHJpkQMCHf1oKQw8LFW/0w8=

--- a/miner.go
+++ b/miner.go
@@ -109,9 +109,9 @@ func (m *Miner) Run(ctx context.Context) error {
 	}
 
 	if m.onSectorUpdated != nil {
-		m.sealing = NewWithOnSectorUpdated(m.api, m.sb, m.ds, m.worker, m.maddr, m.onSectorUpdated)
+		m.sealing = NewSealingWithOnSectorUpdated(m.api, m.sb, m.ds, m.worker, m.maddr, m.onSectorUpdated)
 	} else {
-		m.sealing = New(m.api, m.sb, m.ds, m.worker, m.maddr)
+		m.sealing = NewSealing(m.api, m.sb, m.ds, m.worker, m.maddr)
 	}
 
 	go m.sealing.Run(ctx) // nolint: errcheck

--- a/miner.go
+++ b/miner.go
@@ -13,18 +13,18 @@ import (
 
 var log = logging.Logger("storageminer")
 
-const SectorStorePrefix = "/sectors"
-
 // SectorBuilderAPI provides a method set used by the miner in order to interact
 // with the go-sectorbuilder package. This method set exposes a subset of the
 // methods defined on the sectorbuilder.Interface interface.
 type SectorBuilderAPI interface {
-	SectorSize() uint64
-	SealPreCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, pieces []sectorbuilder.PublicPieceInfo) (sectorbuilder.RawSealPreCommitOutput, error)
-	SealCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, seed ffi.SealSeed, pieces []sectorbuilder.PublicPieceInfo, rspco sectorbuilder.RawSealPreCommitOutput) (proof []byte, err error)
-	RateLimit() func()
-	AddPiece(ctx context.Context, pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error)
 	AcquireSectorId() (uint64, error)
+	AddPiece(ctx context.Context, pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error)
+	DropStaged(context.Context, uint64) error
+	FinalizeSector(context.Context, uint64) error
+	RateLimit() func()
+	SealCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, seed ffi.SealSeed, pieces []sectorbuilder.PublicPieceInfo, rspco sectorbuilder.RawSealPreCommitOutput) (proof []byte, err error)
+	SealPreCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, pieces []sectorbuilder.PublicPieceInfo) (sectorbuilder.RawSealPreCommitOutput, error)
+	SectorSize() uint64
 }
 
 var _ SectorBuilderAPI = new(sectorbuilder.SectorBuilder)

--- a/miner.go
+++ b/miner.go
@@ -23,7 +23,7 @@ type SectorBuilderAPI interface {
 	SealPreCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, pieces []sectorbuilder.PublicPieceInfo) (sectorbuilder.RawSealPreCommitOutput, error)
 	SealCommit(ctx context.Context, sectorID uint64, ticket ffi.SealTicket, seed ffi.SealSeed, pieces []sectorbuilder.PublicPieceInfo, rspco sectorbuilder.RawSealPreCommitOutput) (proof []byte, err error)
 	RateLimit() func()
-	AddPiece(pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error)
+	AddPiece(ctx context.Context, pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error)
 	AcquireSectorId() (uint64, error)
 }
 

--- a/node_api.go
+++ b/node_api.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 )
 
@@ -58,6 +59,10 @@ type NodeAPI interface {
 	// ordering of the deals must match the ordering of the related pieces in
 	// the sector.
 	CheckSealing(ctx context.Context, commD []byte, dealIDs []uint64, ticket SealTicket) *CheckSealingError
+
+	// WalletHas checks the wallet for the key associated with the provided
+	// address.
+	WalletHas(ctx context.Context, addr address.Address) (bool, error)
 }
 
 type PieceInfo struct {

--- a/sealing.go
+++ b/sealing.go
@@ -91,7 +91,7 @@ func (m *Sealing) SealPiece(ctx context.Context, size uint64, r io.Reader, secto
 
 	log.Infof("Seal piece for deal %d", dealID)
 
-	ppi, err := m.sb.AddPiece(size, sectorID, r, []uint64{})
+	ppi, err := m.sb.AddPiece(ctx, size, sectorID, r, []uint64{})
 	if err != nil {
 		return xerrors.Errorf("adding piece to sector: %w", err)
 	}

--- a/sealing.go
+++ b/sealing.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-padreader"
@@ -27,6 +28,11 @@ type Sealing struct {
 	// onSectorUpdated is called each time a sector transitions from one state
 	// to some other state, if defined. It is non-nil during test.
 	onSectorUpdated func(uint64, SectorState)
+
+	// runCompleteWg is incremented when Mining is created, and will prevent
+	// new sectors from being added to the StateGroup before existing sectors
+	// have been restarted. When Mining#Run exits, runCompleteWg is decremented.
+	runCompleteWg sync.WaitGroup
 }
 
 func New(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batching, worker address.Address, maddr address.Address) *Sealing {
@@ -42,12 +48,16 @@ func NewWithOnSectorUpdated(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batch
 		onSectorUpdated: onSectorUpdated,
 	}
 
+	s.runCompleteWg.Add(1)
+
 	s.sectors = statemachine.New(namespace.Wrap(ds, datastore.NewKey(SectorStorePrefix)), s, SectorInfo{})
 
 	return s
 }
 
 func (m *Sealing) Run(ctx context.Context) error {
+	defer m.runCompleteWg.Done()
+
 	if err := m.restartSectors(ctx); err != nil {
 		log.Errorf("%+v", err)
 		return xerrors.Errorf("failed load sector states: %w", err)
@@ -57,6 +67,8 @@ func (m *Sealing) Run(ctx context.Context) error {
 }
 
 func (m *Sealing) Stop(ctx context.Context) error {
+	m.runCompleteWg.Add(1)
+
 	return m.sectors.Stop(ctx)
 }
 
@@ -86,7 +98,10 @@ func (m *Sealing) SealPiece(ctx context.Context, size uint64, r io.Reader, secto
 }
 
 func (m *Sealing) newSector(ctx context.Context, sid uint64, dealID uint64, ppi sectorbuilder.PublicPieceInfo) error {
+	m.runCompleteWg.Wait()
+
 	log.Infof("Start sealing %d", sid)
+
 	return m.sectors.Send(sid, SectorStart{
 		id: sid,
 		pieces: []Piece{

--- a/sealing.go
+++ b/sealing.go
@@ -35,11 +35,11 @@ type Sealing struct {
 	runCompleteWg sync.WaitGroup
 }
 
-func New(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batching, worker address.Address, maddr address.Address) *Sealing {
-	return NewWithOnSectorUpdated(api, sb, ds, worker, maddr, nil)
+func NewSealing(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batching, worker address.Address, maddr address.Address) *Sealing {
+	return NewSealingWithOnSectorUpdated(api, sb, ds, worker, maddr, nil)
 }
 
-func NewWithOnSectorUpdated(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batching, worker address.Address, maddr address.Address, onSectorUpdated func(uint64, SectorState)) *Sealing {
+func NewSealingWithOnSectorUpdated(api NodeAPI, sb SectorBuilderAPI, ds datastore.Batching, worker address.Address, maddr address.Address, onSectorUpdated func(uint64, SectorState)) *Sealing {
 	s := &Sealing{
 		api:             api,
 		maddr:           maddr,

--- a/sector_states.go
+++ b/sector_states.go
@@ -7,7 +7,7 @@ const (
 	UndefinedSectorState SectorState = iota
 
 	// happy path
-	Empty   // an empty sector
+	Empty
 	Packing // sector not in sealStore, and not on chain
 
 	Unsealed      // sealing / queued
@@ -15,9 +15,9 @@ const (
 	WaitSeed      // waiting for seed
 	Committing
 	CommitWait // waiting for message to land on chain
+	FinalizeSector
 	Proving
 	_ // reserved
-	_
 	_
 	_
 
@@ -57,6 +57,7 @@ var SectorStates = []string{
 	WaitSeed:             "WaitSeed",
 	Committing:           "Committing",
 	CommitWait:           "CommitWait",
+	FinalizeSector:       "FinalizeSector",
 	Proving:              "Proving",
 
 	SealFailed:       "SealFailed",

--- a/test/fake_sector_builder.go
+++ b/test/fake_sector_builder.go
@@ -34,3 +34,11 @@ func (fakeSectorBuilder) AddPiece(ctx context.Context, pieceSize uint64, sectorI
 func (fakeSectorBuilder) AcquireSectorId() (uint64, error) {
 	return 42, nil
 }
+
+func (fakeSectorBuilder) DropStaged(context.Context, uint64) error {
+	return nil
+}
+
+func (fakeSectorBuilder) FinalizeSector(context.Context, uint64) error {
+	return nil
+}

--- a/test/fake_sector_builder.go
+++ b/test/fake_sector_builder.go
@@ -26,7 +26,7 @@ func (fakeSectorBuilder) RateLimit() func() {
 	return func() {}
 }
 
-func (fakeSectorBuilder) AddPiece(pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error) {
+func (fakeSectorBuilder) AddPiece(ctx context.Context, pieceSize uint64, sectorID uint64, file io.Reader, existingPieceSizes []uint64) (sectorbuilder.PublicPieceInfo, error) {
 	return sectorbuilder.PublicPieceInfo{Size: pieceSize}, nil
 }
 

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -31,6 +31,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 		then(storage.WaitSeed).
 		then(storage.Committing).
 		then(storage.CommitWait).
+		then(storage.FinalizeSector).
 		then(storage.Proving).
 		end()
 
@@ -92,6 +93,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		then(storage.WaitSeed).
 		then(storage.Committing).
 		then(storage.CommitWait).
+		then(storage.FinalizeSector).
 		then(storage.Proving).
 		end()
 

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,12 @@ const PaddedBytesOneKiBSector = 1024
 func TestSuccessfulPieceSealingFlow(t *testing.T) {
 	ctx := context.Background()
 
+	maddr, err := address.NewIDAddress(55)
+	require.NoError(t, err)
+
+	waddr, err := address.NewIDAddress(66)
+	require.NoError(t, err)
+
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, storage.Packing).
 		then(storage.Unsealed).
@@ -35,7 +42,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 		then(storage.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(newFakeNode(), datastore.NewMapDatastore(), &fakeSectorBuilder{}, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(newFakeNode(), datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, waddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -59,6 +66,12 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 
 func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 	ctx := context.Background()
+
+	maddr, err := address.NewIDAddress(55)
+	require.NoError(t, err)
+
+	waddr, err := address.NewIDAddress(66)
+	require.NoError(t, err)
 
 	// we'll assert the contents of this slice at the end of the test
 	var selfDealPieceSizes []uint64
@@ -97,7 +110,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		then(storage.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, maddr, waddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -125,6 +138,12 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 	ctx := context.Background()
 
+	maddr, err := address.NewIDAddress(55)
+	require.NoError(t, err)
+
+	waddr, err := address.NewIDAddress(66)
+	require.NoError(t, err)
+
 	// configure behavior of the fake node
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
@@ -143,7 +162,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 		then(storage.PreCommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, waddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -165,6 +184,12 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 	ctx := context.Background()
 
+	maddr, err := address.NewIDAddress(55)
+	require.NoError(t, err)
+
+	waddr, err := address.NewIDAddress(66)
+	require.NoError(t, err)
+
 	// configure behavior of the fake node
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
@@ -185,7 +210,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 		then(storage.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, waddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -206,6 +231,12 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 
 func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 	ctx := context.Background()
+
+	maddr, err := address.NewIDAddress(55)
+	require.NoError(t, err)
+
+	waddr, err := address.NewIDAddress(66)
+	require.NoError(t, err)
 
 	// configure behavior of the fake node
 	fakeNode := func() *fakeNode {
@@ -228,7 +259,7 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 		then(storage.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, waddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {

--- a/test/sector_state_tracker.go
+++ b/test/sector_state_tracker.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-storage-miner"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-storage-miner"
 )
 
 type sectorStateTracker struct {

--- a/types.go
+++ b/types.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/filecoin-project/go-sectorbuilder"
+	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
 	"github.com/ipfs/go-cid"
 )
 

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
-	"gotest.tools/assert"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSectorInfoSelialization(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,13 @@
 package storage
 
 import (
+	"io"
 	"math/bits"
+	"math/rand"
+	"sync"
 
 	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
+	"github.com/hashicorp/go-multierror"
 )
 
 func fillersFromRem(toFill uint64) ([]uint64, error) {
@@ -40,6 +44,44 @@ func fillersFromRem(toFill uint64) ([]uint64, error) {
 		out[i] = sectorbuilder.UserBytesForSectorSize(psize)
 	}
 	return out, nil
+}
+
+func (m *Sealing) fastPledgeCommitment(size uint64, parts uint64) (commP [sectorbuilder.CommLen]byte, err error) {
+	parts = 1 << bits.Len64(parts) // round down to nearest power of 2
+	if size/parts < 127 {
+		parts = size / 127
+	}
+
+	piece := sectorbuilder.UserBytesForSectorSize((size + size/127) / parts)
+	out := make([]sectorbuilder.PublicPieceInfo, parts)
+	var lk sync.Mutex
+
+	var wg sync.WaitGroup
+	wg.Add(int(parts))
+	for i := uint64(0); i < parts; i++ {
+		go func(i uint64) {
+			defer wg.Done()
+
+			commP, perr := sectorbuilder.GeneratePieceCommitment(io.LimitReader(rand.New(rand.NewSource(42+int64(i))), int64(piece)), piece)
+
+			lk.Lock()
+			if perr != nil {
+				err = multierror.Append(err, perr)
+			}
+			out[i] = sectorbuilder.PublicPieceInfo{
+				Size:  piece,
+				CommP: commP,
+			}
+			lk.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	return sectorbuilder.GenerateDataCommitment(m.sb.SectorSize(), out)
 }
 
 func (m *Sealing) ListSectors() ([]SectorInfo, error) {

--- a/utils.go
+++ b/utils.go
@@ -46,7 +46,8 @@ func fillersFromRem(toFill uint64) ([]uint64, error) {
 	return out, nil
 }
 
-func (m *Sealing) fastPledgeCommitment(size uint64, parts uint64) (commP [sectorbuilder.CommLen]byte, err error) {
+// FastPledgeCommitment generates parts-quantity piece commitments in parallel.
+func (m *Sealing) FastPledgeCommitment(size uint64, parts uint64) (commP [sectorbuilder.CommLen]byte, err error) {
 	parts = 1 << bits.Len64(parts) // round down to nearest power of 2
 	if size/parts < 127 {
 		parts = size / 127

--- a/utils_test.go
+++ b/utils_test.go
@@ -41,5 +41,4 @@ func TestFillersFromRem(t *testing.T) {
 		ub = sectorbuilder.UserBytesForSectorSize(uint64(9) << i)
 		testFill(t, ub, []uint64{ub1, ub4})
 	}
-
 }


### PR DESCRIPTION
## Why is this PR needed?

Lotus has made some improvements to their storage miner, and we need to mirror those changes into this repo.

## What's in this PR?

Highlights include:

- fast CommP generation
- sector finalization
- plumb miner and worker addresses to Miner constructor
- add preflight check, copied from lotus
