### PR TITLE
roll back to old node API to support go-filecoin integration

### DIFF
--- a/apis/node/errors.go
+++ b/apis/node/errors.go
@@ -36,8 +36,8 @@ type CheckSealingError struct {
 	EType CheckSealingErrorType
 }
 
-func NewCheckSealingError(inner error, etype CheckSealingErrorType) *CheckSealingError {
-	return &CheckSealingError{inner: inner, EType: etype}
+func NewCheckSealingError(inner error, etype CheckSealingErrorType) CheckSealingError {
+	return CheckSealingError{inner: inner, EType: etype}
 }
 
 func (c CheckSealingError) Inner() error {
@@ -57,8 +57,8 @@ type GetSealSeedError struct {
 	EType GetSealSeedErrorType
 }
 
-func NewGetSealSeedError(inner error, etype GetSealSeedErrorType) *GetSealSeedError {
-	return &GetSealSeedError{inner: inner, EType: etype}
+func NewGetSealSeedError(inner error, etype GetSealSeedErrorType) GetSealSeedError {
+	return GetSealSeedError{inner: inner, EType: etype}
 }
 
 func (c GetSealSeedError) Unwrap() error {

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Interface interface {
-	// SendMessage creates and sends a blockchain message with the provided
-	// arguments and returns its identity.
-	SendMessage(from, to address.Address, method abi.MethodNum, value abi.TokenAmount, params []byte) (cid.Cid, error)
+	// SendSelfDeals publishes storage deals using the provided inputs and
+	// returns the identity of the corresponding PublishStorageDeals message.
+	SendSelfDeals(context.Context, ...abi.PieceInfo) (cid.Cid, error)
 
-	// WaitMessage blocks until a message with provided CID is mined into a
-	// block.
-	WaitMessage(context.Context, cid.Cid) (MsgWait, error)
+	// WaitForSelfDeals blocks until the PublishStorageDeals message is mined
+	// into a block and then returns the referenced deal IDs.
+	WaitForSelfDeals(context.Context, cid.Cid) ([]abi.DealID, uint8, error)
 
 	// GetMinerWorkerAddressFromChainHead produces the worker address associated
 	// with the provider miner address at the current head.

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -51,7 +51,7 @@ type Interface interface {
 
 	// GetSealSeed requests that a seal seed be provided through the return channel the given block interval after the preCommitMsg arrives on chain.
 	// It expects to be notified through the invalidated channel if a re-org sets the chain back to before the height at the interval.
-	GetSealSeed(ctx context.Context, preCommitMsg cid.Cid, interval uint64) (<-chan SealSeed, <-chan SeedInvalidated, <-chan FinalityReached, <-chan *GetSealSeedError)
+	GetSealSeed(ctx context.Context, preCommitMsg cid.Cid, interval uint64) (<-chan SealSeed, <-chan SeedInvalidated, <-chan FinalityReached, <-chan GetSealSeedError)
 
 	// CheckPieces ensures that the provides pieces' metadata exist in
 	// not yet-expired on-chain storage deals.

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -17,7 +17,7 @@ type fakeNode struct {
 	checkSealing             func(ctx context.Context, commD []byte, dealIDs []abi.DealID, ticket node.SealTicket) *node.CheckSealingError
 	getMinerWorkerAddress    func(ctx context.Context, maddr address.Address) (address.Address, error)
 	getReplicaCommitmentByID func(ctx context.Context, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error)
-	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan *node.GetSealSeedError)
+	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError)
 	getSealTicket            func(context.Context) (node.SealTicket, error)
 	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
@@ -43,7 +43,7 @@ func newFakeNode() *fakeNode {
 		getReplicaCommitmentByID: func(ctx context.Context, sectorNum abi.SectorNumber) ([]byte, bool, error) {
 			return nil, false, nil
 		},
-		getSealSeed: func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan *node.GetSealSeedError) {
+		getSealSeed: func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError) {
 			seedChan := make(chan node.SealSeed)
 			go func() {
 				seedChan <- node.SealSeed{
@@ -52,7 +52,7 @@ func newFakeNode() *fakeNode {
 				}
 			}()
 
-			return seedChan, make(chan node.SeedInvalidated), make(chan node.FinalityReached), make(chan *node.GetSealSeedError)
+			return seedChan, make(chan node.SeedInvalidated), make(chan node.FinalityReached), make(chan node.GetSealSeedError)
 		},
 		getSealTicket: func(context.Context) (node.SealTicket, error) {
 			return node.SealTicket{
@@ -107,7 +107,7 @@ func (f *fakeNode) GetSealTicket(ctx context.Context) (node.SealTicket, error) {
 	return f.getSealTicket(ctx)
 }
 
-func (f *fakeNode) GetSealSeed(ctx context.Context, preCommitMsgCid cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan *node.GetSealSeedError) {
+func (f *fakeNode) GetSealSeed(ctx context.Context, preCommitMsgCid cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError) {
 	return f.getSealSeed(ctx, preCommitMsgCid, interval)
 }
 

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -1,23 +1,15 @@
 package test
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-
-	"github.com/filecoin-project/go-storage-miner/apis/node"
-
-	"github.com/filecoin-project/specs-actors/actors/builtin"
-
-	"github.com/filecoin-project/specs-actors/actors/builtin/market"
-
-	"github.com/filecoin-project/specs-actors/actors/runtime"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	mh "github.com/multiformats/go-multihash"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
 )
 
 type fakeNode struct {
@@ -27,23 +19,17 @@ type fakeNode struct {
 	getReplicaCommitmentByID func(ctx context.Context, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan *node.GetSealSeedError)
 	getSealTicket            func(context.Context) (node.SealTicket, error)
-	sendMessage              func(from, to address.Address, method abi.MethodNum, value abi.TokenAmount, params []byte) (cid.Cid, error)
 	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
 	sendReportFaults         func(ctx context.Context, sectorNums ...abi.SectorNumber) (cid.Cid, error)
+	sendSelfDeals            func(context.Context, ...abi.PieceInfo) (cid.Cid, error)
 	waitForProveCommitSector func(context.Context, cid.Cid) (exitCode uint8, err error)
 	waitForReportFaults      func(context.Context, cid.Cid) (uint8, error)
-	waitMessage              func(ctx context.Context, msg cid.Cid) (node.MsgWait, error)
+	waitForSelfDeals         func(context.Context, cid.Cid) ([]abi.DealID, uint8, error)
 	walletHas                func(ctx context.Context, addr address.Address) (bool, error)
 }
 
 func newFakeNode() *fakeNode {
-	m := make(map[cid.Cid]runtime.CBORMarshaler)
-
-	m[createCidForTesting(int(builtin.MethodsMarket.PublishStorageDeals))] = &market.PublishStorageDealsReturn{
-		IDs: []abi.DealID{42, 99},
-	}
-
 	return &fakeNode{
 		checkPieces: func(ctx context.Context, sectorNum abi.SectorNumber, pieces []node.Piece) *node.CheckPiecesError {
 			return nil
@@ -74,9 +60,6 @@ func newFakeNode() *fakeNode {
 				TicketBytes: []byte{1, 2, 3},
 			}, nil
 		},
-		sendMessage: func(from, to address.Address, method abi.MethodNum, value abi.TokenAmount, params []byte) (c cid.Cid, err error) {
-			return createCidForTesting(int(method)), nil
-		},
 		sendPreCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
@@ -86,32 +69,17 @@ func newFakeNode() *fakeNode {
 		sendReportFaults: func(ctx context.Context, sectorNumbers ...abi.SectorNumber) (i cid.Cid, e error) {
 			return createCidForTesting(42), nil
 		},
+		sendSelfDeals: func(ctx context.Context, info ...abi.PieceInfo) (c cid.Cid, err error) {
+			panic("by default, no self deals will be made")
+		},
 		waitForProveCommitSector: func(context.Context, cid.Cid) (exitCode uint8, err error) {
 			return 0, nil
 		},
 		waitForReportFaults: func(i context.Context, i2 cid.Cid) (u uint8, e error) {
 			return 0, nil
 		},
-		waitMessage: func(ctx context.Context, msg cid.Cid) (wait node.MsgWait, err error) {
-			v, ok := m[msg]
-
-			if !ok {
-				panic(fmt.Sprintf("test setup is missing message cid: %s, map: %+v", msg, m))
-			}
-
-			buf := new(bytes.Buffer)
-			if err := v.MarshalCBOR(buf); err != nil {
-				panic(fmt.Sprintf("test failed to marshal CBOR bytes: %s", err))
-			}
-
-			return node.MsgWait{
-				Receipt: node.MessageReceipt{
-					ExitCode: 0,
-					Return:   buf.Bytes(),
-					GasUsed:  abi.NewTokenAmount(0),
-				},
-				Height: 0,
-			}, nil
+		waitForSelfDeals: func(ctx context.Context, c cid.Cid) (ids []abi.DealID, u uint8, err error) {
+			panic("by default, no self deals will be made")
 		},
 		walletHas: func(ctx context.Context, addr address.Address) (b bool, e error) {
 			return true, nil
@@ -155,20 +123,20 @@ func (f *fakeNode) GetReplicaCommitmentByID(ctx context.Context, sectorNum abi.S
 	return f.getReplicaCommitmentByID(ctx, sectorNum)
 }
 
-func (f *fakeNode) SendMessage(from, to address.Address, method abi.MethodNum, value abi.TokenAmount, params []byte) (cid.Cid, error) {
-	return f.sendMessage(from, to, method, value, params)
-}
-
 func (f *fakeNode) SendReportFaults(ctx context.Context, sectorNumbers ...abi.SectorNumber) (cid.Cid, error) {
 	return f.sendReportFaults(ctx, sectorNumbers...)
+}
+
+func (f *fakeNode) SendSelfDeals(ctx context.Context, pieces ...abi.PieceInfo) (cid.Cid, error) {
+	return f.sendSelfDeals(ctx, pieces...)
 }
 
 func (f *fakeNode) WaitForReportFaults(ctx context.Context, msg cid.Cid) (uint8, error) {
 	return f.waitForReportFaults(ctx, msg)
 }
 
-func (f *fakeNode) WaitMessage(ctx context.Context, msg cid.Cid) (node.MsgWait, error) {
-	return f.waitMessage(ctx, msg)
+func (f *fakeNode) WaitForSelfDeals(ctx context.Context, msg cid.Cid) ([]abi.DealID, uint8, error) {
+	return f.waitForSelfDeals(ctx, msg)
 }
 
 func (f *fakeNode) WalletHas(ctx context.Context, addr address.Address) (bool, error) {


### PR DESCRIPTION
## What's in this PR?

To break go-filecoin as little as possible, we roll back to the original node API with the understanding that we'll cut over to `SendMessage` `WaitMessage` at some future time.