### PR TITLE
add explicit state identifiers to getter methods

### DIFF
--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -19,7 +19,7 @@ type Interface interface {
 
 	// GetMinerWorkerAddress produces the worker address associated with the
 	// miner.
-	GetMinerWorkerAddress(context.Context) (address.Address, error)
+	GetMinerWorkerAddress(context.Context, TipSetToken) (address.Address, error)
 
 	// SendPreCommitSector publishes the miner's pre-commitment of a sector to a
 	// particular chain and returns the identity of the corresponding message.
@@ -42,7 +42,7 @@ type Interface interface {
 
 	// GetSealTicket produces a ticket from the chain to which the miner commits
 	// when they start encoding a sector.
-	GetSealTicket(context.Context) (SealTicket, error)
+	GetSealTicket(context.Context, TipSetToken) (SealTicket, error)
 
 	// GetReplicaCommitmentByID produces the CommR associated with the given
 	// sector as it appears in a pre-commit message. If the sector has not been
@@ -66,4 +66,7 @@ type Interface interface {
 	// WalletHas checks the wallet for the key associated with the provided
 	// address.
 	WalletHas(ctx context.Context, addr address.Address) (bool, error)
+
+	// GetChainHead produces the tipset identifier for the chain's head.
+	GetChainHead(ctx context.Context) (TipSetToken, error)
 }

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -17,9 +17,9 @@ type Interface interface {
 	// into a block and then returns the referenced deal IDs.
 	WaitForSelfDeals(context.Context, cid.Cid) ([]abi.DealID, uint8, error)
 
-	// GetMinerWorkerAddressFromChainHead produces the worker address associated
-	// with the provider miner address at the current head.
-	GetMinerWorkerAddressFromChainHead(context.Context, address.Address) (address.Address, error)
+	// GetMinerWorkerAddress produces the worker address associated with the
+	// miner.
+	GetMinerWorkerAddress(context.Context) (address.Address, error)
 
 	// SendPreCommitSector publishes the miner's pre-commitment of a sector to a
 	// particular chain and returns the identity of the corresponding message.

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -44,10 +44,10 @@ type Interface interface {
 	// when they start encoding a sector.
 	GetSealTicket(context.Context, TipSetToken) (SealTicket, error)
 
-	// GetReplicaCommitmentByID produces the CommR associated with the given
-	// sector as it appears in a pre-commit message. If the sector has not been
-	// pre-committed, wasFound will be false.
-	GetReplicaCommitmentByID(ctx context.Context, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error)
+	// GetSealedCID produces the sealed sector's CID associated with the given
+	// sector number as it appears in a pre-commit message. If the sector has
+	// not been  pre-committed, wasFound will be false.
+	GetSealedCID(context.Context, TipSetToken, abi.SectorNumber) (sealedCID cid.Cid, wasFound bool, err error)
 
 	// GetSealSeed requests that a seal seed be provided through the return channel the given block interval after the preCommitMsg arrives on chain.
 	// It expects to be notified through the invalidated channel if a re-org sets the chain back to before the height at the interval.

--- a/apis/node/types.go
+++ b/apis/node/types.go
@@ -8,6 +8,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// TipSetToken is the implementation-nonspecific identity for a tipset.
+type TipSetToken []byte
+
 type FinalityReached struct{}
 type SeedInvalidated struct{}
 

--- a/miner.go
+++ b/miner.go
@@ -81,7 +81,12 @@ func (m *Miner) Stop(ctx context.Context) error {
 }
 
 func (m *Miner) runPreflightChecks(ctx context.Context) error {
-	waddr, err := m.api.GetMinerWorkerAddress(ctx)
+	tok, err := m.api.GetChainHead(ctx)
+	if err != nil {
+		return xerrors.Errorf("failed to get chain head: %w", err)
+	}
+
+	waddr, err := m.api.GetMinerWorkerAddress(ctx, tok)
 	if err != nil {
 		return xerrors.Errorf("error acquiring worker address: %w", err)
 	}

--- a/miner.go
+++ b/miner.go
@@ -81,7 +81,7 @@ func (m *Miner) Stop(ctx context.Context) error {
 }
 
 func (m *Miner) runPreflightChecks(ctx context.Context) error {
-	waddr, err := m.api.GetMinerWorkerAddressFromChainHead(ctx, m.maddr)
+	waddr, err := m.api.GetMinerWorkerAddress(ctx)
 	if err != nil {
 		return xerrors.Errorf("error acquiring worker address: %w", err)
 	}

--- a/sealing/states.go
+++ b/sealing/states.go
@@ -68,8 +68,13 @@ func (m *Sealing) handleUnsealed(ctx statemachine.Context, sector SectorInfo) er
 		}
 	}
 
+	tok, err := m.api.GetChainHead(ctx.Context())
+	if err != nil {
+		return xerrors.Errorf("failed to get chain head: %w", err)
+	}
+
 	log.Infow("performing sector replication...", "sector", sector.SectorNum)
-	ticket, err := m.api.GetSealTicket(ctx.Context())
+	ticket, err := m.api.GetSealTicket(ctx.Context(), tok)
 	if err != nil {
 		return ctx.Send(SectorSealFailed{xerrors.Errorf("getting ticket failed: %w", err)})
 	}

--- a/sealing/states_failed.go
+++ b/sealing/states_failed.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"time"
 
-	commcid "github.com/filecoin-project/go-fil-commcid"
-
 	"github.com/filecoin-project/go-storage-miner/apis/node"
 
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/go-statemachine"
 	"golang.org/x/xerrors"
 )

--- a/sealing/states_failed.go
+++ b/sealing/states_failed.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"time"
 
+	commcid "github.com/filecoin-project/go-fil-commcid"
+
 	"github.com/filecoin-project/go-storage-miner/apis/node"
 
 	"github.com/filecoin-project/go-statemachine"
@@ -26,10 +28,21 @@ func failedCooldown(ctx statemachine.Context, sector SectorInfo) error {
 	return nil
 }
 
-func (m *Sealing) checkPreCommitted(ctx statemachine.Context, sector SectorInfo) (commR []byte, wasFound bool, err error) {
-	commR, found, err := m.api.GetReplicaCommitmentByID(ctx.Context(), sector.SectorNum)
+func (m *Sealing) checkPreCommitted(ctx statemachine.Context, sector SectorInfo) ([]byte, bool, error) {
+	tok, err := m.api.GetChainHead(ctx.Context())
 	if err != nil {
-		log.Errorf("handleSealFailed(%d): temp error: %+v", sector.SectorNum, err)
+		return nil, false, xerrors.Errorf("failed to get chain head: %w", err)
+	}
+
+	sealedCID, found, err := m.api.GetSealedCID(ctx.Context(), tok, sector.SectorNum)
+	if err != nil {
+		log.Errorf("checkPreCommitted(%d): temp error: %+v", sector.SectorNum, err)
+		return nil, false, err
+	}
+
+	commR, err := commcid.CIDToReplicaCommitmentV1(sealedCID)
+	if err != nil {
+		log.Errorf("failed to map from sealed CID to CommR: %+v", sector.SectorNum, err)
 		return nil, false, err
 	}
 

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -99,7 +99,7 @@ func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (e
 	return f.waitForProveCommitSector(ctx, msg)
 }
 
-func (f *fakeNode) GetMinerWorkerAddressFromChainHead(ctx context.Context, maddr address.Address) (address.Address, error) {
+func (f *fakeNode) GetMinerWorkerAddress(ctx context.Context) (address.Address, error) {
 	return f.getMinerWorkerAddress(ctx, maddr)
 }
 

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -3,9 +3,8 @@ package test
 import (
 	"context"
 
-	commcid "github.com/filecoin-project/go-fil-commcid"
-
 	"github.com/filecoin-project/go-address"
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -15,10 +15,11 @@ import (
 type fakeNode struct {
 	checkPieces              func(ctx context.Context, sectorNum abi.SectorNumber, pieces []node.Piece) *node.CheckPiecesError
 	checkSealing             func(ctx context.Context, commD []byte, dealIDs []abi.DealID, ticket node.SealTicket) *node.CheckSealingError
-	getMinerWorkerAddress    func(ctx context.Context, maddr address.Address) (address.Address, error)
+	getChainHead             func(ctx context.Context) (node.TipSetToken, error)
+	getMinerWorkerAddress    func(context.Context, node.TipSetToken) (address.Address, error)
 	getReplicaCommitmentByID func(ctx context.Context, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError)
-	getSealTicket            func(context.Context) (node.SealTicket, error)
+	getSealTicket            func(context.Context, node.TipSetToken) (node.SealTicket, error)
 	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
 	sendReportFaults         func(ctx context.Context, sectorNums ...abi.SectorNumber) (cid.Cid, error)
@@ -37,7 +38,10 @@ func newFakeNode() *fakeNode {
 		checkSealing: func(ctx context.Context, commD []byte, dealIDs []abi.DealID, ticket node.SealTicket) *node.CheckSealingError {
 			return nil
 		},
-		getMinerWorkerAddress: func(ctx context.Context, maddr address.Address) (a address.Address, err error) {
+		getChainHead: func(ctx context.Context) (token node.TipSetToken, err error) {
+			return node.TipSetToken{1, 2, 3}, nil
+		},
+		getMinerWorkerAddress: func(ctx context.Context, tok node.TipSetToken) (a address.Address, err error) {
 			return address.NewIDAddress(42)
 		},
 		getReplicaCommitmentByID: func(ctx context.Context, sectorNum abi.SectorNumber) ([]byte, bool, error) {
@@ -54,16 +58,13 @@ func newFakeNode() *fakeNode {
 
 			return seedChan, make(chan node.SeedInvalidated), make(chan node.FinalityReached), make(chan node.GetSealSeedError)
 		},
-		getSealTicket: func(context.Context) (node.SealTicket, error) {
+		getSealTicket: func(context.Context, node.TipSetToken) (node.SealTicket, error) {
 			return node.SealTicket{
 				BlockHeight: 42,
 				TicketBytes: []byte{1, 2, 3},
 			}, nil
 		},
 		sendPreCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error) {
-			return createCidForTesting(42), nil
-		},
-		sendProveCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
 		sendReportFaults: func(ctx context.Context, sectorNumbers ...abi.SectorNumber) (i cid.Cid, e error) {
@@ -84,31 +85,10 @@ func newFakeNode() *fakeNode {
 		walletHas: func(ctx context.Context, addr address.Address) (b bool, e error) {
 			return true, nil
 		},
+		sendProveCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
+			return createCidForTesting(42), nil
+		},
 	}
-}
-
-func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error) {
-	return f.sendPreCommitSector(ctx, sectorNum, commR, ticket, pieces...)
-}
-
-func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
-	return f.sendProveCommitSector(ctx, sectorNum, proof, dealIds...)
-}
-
-func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (exitCode uint8, err error) {
-	return f.waitForProveCommitSector(ctx, msg)
-}
-
-func (f *fakeNode) GetMinerWorkerAddress(ctx context.Context) (address.Address, error) {
-	return f.getMinerWorkerAddress(ctx, maddr)
-}
-
-func (f *fakeNode) GetSealTicket(ctx context.Context) (node.SealTicket, error) {
-	return f.getSealTicket(ctx)
-}
-
-func (f *fakeNode) GetSealSeed(ctx context.Context, preCommitMsgCid cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError) {
-	return f.getSealSeed(ctx, preCommitMsgCid, interval)
 }
 
 func (f *fakeNode) CheckPieces(ctx context.Context, sectorNum abi.SectorNumber, pieces []node.Piece) *node.CheckPiecesError {
@@ -119,8 +99,32 @@ func (f *fakeNode) CheckSealing(ctx context.Context, commD []byte, dealIDs []abi
 	return f.checkSealing(ctx, commD, dealIDs, ticket)
 }
 
+func (f *fakeNode) GetChainHead(ctx context.Context) (node.TipSetToken, error) {
+	return f.getChainHead(ctx)
+}
+
+func (f *fakeNode) GetMinerWorkerAddress(ctx context.Context, tok node.TipSetToken) (address.Address, error) {
+	return f.getMinerWorkerAddress(ctx, tok)
+}
+
 func (f *fakeNode) GetReplicaCommitmentByID(ctx context.Context, sectorNum abi.SectorNumber) (commR []byte, wasFound bool, err error) {
 	return f.getReplicaCommitmentByID(ctx, sectorNum)
+}
+
+func (f *fakeNode) GetSealSeed(ctx context.Context, preCommitMsg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError) {
+	return f.getSealSeed(ctx, preCommitMsg, interval)
+}
+
+func (f *fakeNode) GetSealTicket(ctx context.Context, tok node.TipSetToken) (node.SealTicket, error) {
+	return f.getSealTicket(ctx, tok)
+}
+
+func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error) {
+	return f.sendPreCommitSector(ctx, sectorNum, commR, ticket, pieces...)
+}
+
+func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
+	return f.sendProveCommitSector(ctx, sectorNum, proof, dealIds...)
 }
 
 func (f *fakeNode) SendReportFaults(ctx context.Context, sectorNumbers ...abi.SectorNumber) (cid.Cid, error) {
@@ -129,6 +133,10 @@ func (f *fakeNode) SendReportFaults(ctx context.Context, sectorNumbers ...abi.Se
 
 func (f *fakeNode) SendSelfDeals(ctx context.Context, pieces ...abi.PieceInfo) (cid.Cid, error) {
 	return f.sendSelfDeals(ctx, pieces...)
+}
+
+func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (exitCode uint8, err error) {
+	return f.waitForProveCommitSector(ctx, msg)
 }
 
 func (f *fakeNode) WaitForReportFaults(ctx context.Context, msg cid.Cid) (uint8, error) {


### PR DESCRIPTION
## Why does this exist?

None of our getter methods accepted a state identifier; they were all implicitly scoped to the chain head. See [this convo](https://filecoinproject.slack.com/archives/CPLLE0ZQX/p1582128754110800?thread_ts=1582128521.110500&cid=CPLLE0ZQX) for more background information.

## What's in this PR?

- add an implementation-nonspecific, opaque `TipSetToken`, used to identify a TipSet
- add `TipSetToken` parameter to `GetSealTicket` and `GetSealedCID` and `GetMinerWorkerAddress`
- add `GetChainHead` method