### PR TITLE
communicate self-deal terms back to node

### DIFF
--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -11,7 +11,7 @@ import (
 type Interface interface {
 	// SendSelfDeals publishes storage deals using the provided inputs and
 	// returns the identity of the corresponding PublishStorageDeals message.
-	SendSelfDeals(ctx context.Context, startEpoch, endEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error)
+	SendSelfDeals(ctx context.Context, startEpoch, expiryEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error)
 
 	// WaitForSelfDeals blocks until the PublishStorageDeals message is mined
 	// into a block and then returns the referenced deal IDs.

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -11,7 +11,7 @@ import (
 type Interface interface {
 	// SendSelfDeals publishes storage deals using the provided inputs and
 	// returns the identity of the corresponding PublishStorageDeals message.
-	SendSelfDeals(context.Context, ...abi.PieceInfo) (cid.Cid, error)
+	SendSelfDeals(ctx context.Context, startEpoch, endEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error)
 
 	// WaitForSelfDeals blocks until the PublishStorageDeals message is mined
 	// into a block and then returns the referenced deal IDs.
@@ -67,6 +67,7 @@ type Interface interface {
 	// address.
 	WalletHas(ctx context.Context, addr address.Address) (bool, error)
 
-	// GetChainHead produces the tipset identifier for the chain's head.
-	GetChainHead(ctx context.Context) (TipSetToken, error)
+	// GetChainHead produces the tipset identifier and height of the chain's
+	// head.
+	GetChainHead(ctx context.Context) (TipSetToken, abi.ChainEpoch, error)
 }

--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -11,7 +11,7 @@ import (
 type Interface interface {
 	// SendSelfDeals publishes storage deals using the provided inputs and
 	// returns the identity of the corresponding PublishStorageDeals message.
-	SendSelfDeals(ctx context.Context, startEpoch, expiryEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error)
+	SendSelfDeals(ctx context.Context, startEpoch, endEpoch abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error)
 
 	// WaitForSelfDeals blocks until the PublishStorageDeals message is mined
 	// into a block and then returns the referenced deal IDs.

--- a/miner.go
+++ b/miner.go
@@ -5,16 +5,16 @@ import (
 	"errors"
 	"io"
 
-	"github.com/filecoin-project/go-storage-miner/apis/node"
-	"github.com/filecoin-project/go-storage-miner/apis/sectorbuilder"
-
-	sealing2 "github.com/filecoin-project/go-storage-miner/sealing"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+	"github.com/filecoin-project/go-storage-miner/apis/sectorbuilder"
+	"github.com/filecoin-project/go-storage-miner/policies/selfdeal"
+	"github.com/filecoin-project/go-storage-miner/sealing"
 )
 
 var log = logging.Logger("storageminer")
@@ -24,24 +24,28 @@ type Miner struct {
 	maddr   address.Address
 	sb      sectorbuilder.Interface
 	ds      datastore.Batching
-	sealing *sealing2.Sealing
+	sealing *sealing.Sealing
+
+	// used to compute self-deal schedule (e.g. start and expiry epochs)
+	selfDealPolicy selfdeal.Policy
 
 	// onSectorUpdated is called each time a sector transitions from one state
 	// to some other state, if defined. It is non-nil during test.
-	onSectorUpdated func(abi.SectorNumber, sealing2.SectorState)
+	onSectorUpdated func(abi.SectorNumber, sealing.SectorState)
 }
 
-func NewMiner(api node.Interface, ds datastore.Batching, sb sectorbuilder.Interface, maddr address.Address) (*Miner, error) {
-	return NewMinerWithOnSectorUpdated(api, ds, sb, maddr, nil)
+func NewMiner(api node.Interface, ds datastore.Batching, sb sectorbuilder.Interface, maddr address.Address, sdp selfdeal.Policy) (*Miner, error) {
+	return NewMinerWithOnSectorUpdated(api, ds, sb, maddr, sdp, nil)
 }
 
-func NewMinerWithOnSectorUpdated(api node.Interface, ds datastore.Batching, sb sectorbuilder.Interface, maddr address.Address, onSectorUpdated func(abi.SectorNumber, sealing2.SectorState)) (*Miner, error) {
+func NewMinerWithOnSectorUpdated(api node.Interface, ds datastore.Batching, sb sectorbuilder.Interface, maddr address.Address, sdp selfdeal.Policy, onSectorUpdated func(abi.SectorNumber, sealing.SectorState)) (*Miner, error) {
 	return &Miner{
 		api:             api,
 		maddr:           maddr,
 		sb:              sb,
 		ds:              ds,
 		sealing:         nil,
+		selfDealPolicy:  sdp,
 		onSectorUpdated: onSectorUpdated,
 	}, nil
 }
@@ -56,9 +60,9 @@ func (m *Miner) Run(ctx context.Context) error {
 	}
 
 	if m.onSectorUpdated != nil {
-		m.sealing = sealing2.NewSealingWithOnSectorUpdated(m.api, m.sb, m.ds, m.maddr, m.onSectorUpdated)
+		m.sealing = sealing.NewSealingWithOnSectorUpdated(m.api, m.sb, m.ds, m.maddr, m.selfDealPolicy, m.onSectorUpdated)
 	} else {
-		m.sealing = sealing2.NewSealing(m.api, m.sb, m.ds, m.maddr)
+		m.sealing = sealing.NewSealing(m.api, m.sb, m.ds, m.maddr, m.selfDealPolicy)
 	}
 
 	go m.sealing.Run(ctx) // nolint: errcheck

--- a/miner.go
+++ b/miner.go
@@ -26,7 +26,7 @@ type Miner struct {
 	ds      datastore.Batching
 	sealing *sealing.Sealing
 
-	// used to compute self-deal schedule (e.g. start and expiry epochs)
+	// used to compute self-deal schedule (e.g. start and end epochs)
 	selfDealPolicy selfdeal.Policy
 
 	// onSectorUpdated is called each time a sector transitions from one state

--- a/miner.go
+++ b/miner.go
@@ -81,7 +81,7 @@ func (m *Miner) Stop(ctx context.Context) error {
 }
 
 func (m *Miner) runPreflightChecks(ctx context.Context) error {
-	tok, err := m.api.GetChainHead(ctx)
+	tok, _, err := m.api.GetChainHead(ctx)
 	if err != nil {
 		return xerrors.Errorf("failed to get chain head: %w", err)
 	}

--- a/policies/selfdeal/fixed_duration.go
+++ b/policies/selfdeal/fixed_duration.go
@@ -15,16 +15,18 @@ type Chain interface {
 type FixedDurationPolicy struct {
 	api Chain
 
-	// self deal start epoch equals chain head epoch plus delay
-	delay abi.ChainEpoch
+	// An estimate for the number of blocks between the current chain head and
+	// when a sector should have been proven. Used to compute the self-deal
+	// StartEpoch.
+	provingDelay abi.ChainEpoch
 
-	// self deal expiry epoch equals chain head plus delay plus duration
+	// The number of epochs for which the self-dealing miner will receive power.
 	duration abi.ChainEpoch
 }
 
 // NewFixedDurationPolicy produces a new fixed duration self-deal policy.
 func NewFixedDurationPolicy(api Chain, delay abi.ChainEpoch, duration abi.ChainEpoch) FixedDurationPolicy {
-	return FixedDurationPolicy{api: api, delay: delay, duration: duration}
+	return FixedDurationPolicy{api: api, provingDelay: delay, duration: duration}
 }
 
 // Schedule produces the deal terms for this fixed duration self-deal policy.
@@ -35,7 +37,7 @@ func (p *FixedDurationPolicy) Schedule(ctx context.Context, pieces ...abi.PieceI
 	}
 
 	return Schedule{
-		StartEpoch:  epoch + p.delay,
-		ExpiryEpoch: epoch + p.delay + p.duration,
+		StartEpoch: epoch + p.provingDelay,
+		EndEpoch:   epoch + p.provingDelay + p.duration,
 	}, nil
 }

--- a/policies/selfdeal/fixed_duration.go
+++ b/policies/selfdeal/fixed_duration.go
@@ -1,0 +1,41 @@
+package selfdeal
+
+import (
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+)
+
+type Chain interface {
+	GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error)
+}
+
+type FixedDurationPolicy struct {
+	api Chain
+
+	// self deal start epoch equals chain head epoch plus delay
+	delay abi.ChainEpoch
+
+	// self deal expiry epoch equals chain head plus delay plus duration
+	duration abi.ChainEpoch
+}
+
+// NewFixedDurationPolicy produces a new fixed duration self-deal policy.
+func NewFixedDurationPolicy(api Chain, delay abi.ChainEpoch, duration abi.ChainEpoch) FixedDurationPolicy {
+	return FixedDurationPolicy{api: api, delay: delay, duration: duration}
+}
+
+// Schedule produces the deal terms for this fixed duration self-deal policy.
+func (p *FixedDurationPolicy) Schedule(ctx context.Context, pieces ...abi.PieceInfo) (Schedule, error) {
+	_, epoch, err := p.api.GetChainHead(ctx)
+	if err != nil {
+		return Schedule{}, err
+	}
+
+	return Schedule{
+		StartEpoch:  epoch + p.delay,
+		ExpiryEpoch: epoch + p.delay + p.duration,
+	}, nil
+}

--- a/policies/selfdeal/interface.go
+++ b/policies/selfdeal/interface.go
@@ -1,0 +1,16 @@
+package selfdeal
+
+import (
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+)
+
+type Schedule struct {
+	StartEpoch  abi.ChainEpoch
+	ExpiryEpoch abi.ChainEpoch
+}
+
+type Policy interface {
+	Schedule(ctx context.Context, pieces ...abi.PieceInfo) (Schedule, error)
+}

--- a/policies/selfdeal/interface.go
+++ b/policies/selfdeal/interface.go
@@ -6,9 +6,12 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
+// Schedule communicates the time bounds of a self-deal. The self-deal must
+// appear in a sealed (proven) sector no later than StartEpoch, otherwise it
+// is invalid.
 type Schedule struct {
-	StartEpoch  abi.ChainEpoch
-	ExpiryEpoch abi.ChainEpoch
+	StartEpoch abi.ChainEpoch
+	EndEpoch   abi.ChainEpoch
 }
 
 type Policy interface {

--- a/policies/selfdeal/test/fixed_duration_test.go
+++ b/policies/selfdeal/test/fixed_duration_test.go
@@ -42,7 +42,7 @@ func TestFixedDurationScheduleIgnoresSelfDealPieces(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int(s1.StartEpoch), int(s2.StartEpoch))
-	assert.Equal(t, int(s1.ExpiryEpoch), int(s2.ExpiryEpoch))
+	assert.Equal(t, int(s1.EndEpoch), int(s2.EndEpoch))
 }
 
 func TestFixedDurationScheduleBounds(t *testing.T) {
@@ -58,5 +58,5 @@ func TestFixedDurationScheduleBounds(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int(s.StartEpoch), int(headEpoch+delay))
-	assert.Equal(t, int(duration), int(s.ExpiryEpoch)-int(s.StartEpoch))
+	assert.Equal(t, int(duration), int(s.EndEpoch)-int(s.StartEpoch))
 }

--- a/policies/selfdeal/test/fixed_duration_test.go
+++ b/policies/selfdeal/test/fixed_duration_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+	"github.com/filecoin-project/go-storage-miner/policies/selfdeal"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeChain struct {
+	h abi.ChainEpoch
+}
+
+func (f *fakeChain) GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error) {
+	return []byte{1, 2, 3}, f.h, nil
+}
+
+func TestFixedDurationScheduleIgnoresSelfDealPieces(t *testing.T) {
+	policy := selfdeal.NewFixedDurationPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 10, 100)
+
+	pieces := []abi.PieceInfo{{
+		Size:     abi.PaddedPieceSize(1024),
+		PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+	}, {
+		Size:     abi.PaddedPieceSize(1024),
+		PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+	}}
+
+	s1, err := policy.Schedule(context.Background())
+	require.NoError(t, err)
+
+	s2, err := policy.Schedule(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, int(s1.StartEpoch), int(s2.StartEpoch))
+	assert.Equal(t, int(s1.ExpiryEpoch), int(s2.ExpiryEpoch))
+}
+
+func TestFixedDurationScheduleBounds(t *testing.T) {
+	delay := abi.ChainEpoch(10)
+	duration := abi.ChainEpoch(100)
+	headEpoch := abi.ChainEpoch(77)
+
+	policy := selfdeal.NewFixedDurationPolicy(&fakeChain{
+		h: headEpoch,
+	}, delay, duration)
+
+	s, err := policy.Schedule(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, int(s.StartEpoch), int(headEpoch+delay))
+	assert.Equal(t, int(duration), int(s.ExpiryEpoch)-int(s.StartEpoch))
+}

--- a/sealing/garbage.go
+++ b/sealing/garbage.go
@@ -53,7 +53,14 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorNum abi.SectorNumber, 
 		}
 	}
 
-	mcid, err := m.api.SendSelfDeals(ctx, pieces...)
+	_, epoch, err := m.api.GetChainHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	panic("TODO: implement a real policy")
+
+	mcid, err := m.api.SendSelfDeals(ctx, epoch+100, epoch+1000, pieces...)
 	if err != nil {
 		return nil, err
 	}

--- a/sealing/garbage.go
+++ b/sealing/garbage.go
@@ -57,7 +57,7 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorNum abi.SectorNumber, 
 		return nil, handle("failed to create self-deal schedule", err)
 	}
 
-	mcid, err := m.api.SendSelfDeals(ctx, schedule.StartEpoch, schedule.ExpiryEpoch, pieces...)
+	mcid, err := m.api.SendSelfDeals(ctx, schedule.StartEpoch, schedule.EndEpoch, pieces...)
 	if err != nil {
 		return nil, handle("failed to send self-deals to node", err)
 	}

--- a/sealing/sealing.go
+++ b/sealing/sealing.go
@@ -34,7 +34,7 @@ type Sealing struct {
 	sb      sectorbuilder.Interface
 	sectors *statemachine.StateGroup
 
-	// used to compute self-deal schedule (e.g. start and expiry epochs), this
+	// used to compute self-deal schedule (e.g. start and end epochs), this
 	// value is inherited from the Miner which creates this Sealing struct
 	selfDealPolicy selfdeal.Policy
 

--- a/sealing/sealing.go
+++ b/sealing/sealing.go
@@ -48,17 +48,30 @@ type Sealing struct {
 	runCompleteWg sync.WaitGroup
 }
 
-func NewSealing(api node.Interface, sb sectorbuilder.Interface, ds datastore.Batching, maddr address.Address, sdp selfdeal.Policy) *Sealing {
-	return NewSealingWithOnSectorUpdated(api, sb, ds, maddr, sdp, nil)
+func NewSealing(api node.Interface, sb sectorbuilder.Interface, ds datastore.Batching, maddr address.Address) *Sealing {
+	return NewSealingWithOnSectorUpdated(api, sb, ds, maddr, nil)
 }
 
-func NewSealingWithOnSectorUpdated(api node.Interface, sb sectorbuilder.Interface, ds datastore.Batching, maddr address.Address, sdp selfdeal.Policy, onSectorUpdated func(abi.SectorNumber, SectorState)) *Sealing {
+func NewSealingWithOnSectorUpdated(api node.Interface, sb sectorbuilder.Interface, ds datastore.Batching, maddr address.Address, onSectorUpdated func(abi.SectorNumber, SectorState)) *Sealing {
+	// TODO: This value represents the quantity of epochs into the future (from
+	// the chain head-epoch) at which point we expect the pieces in a newly
+	// created self-deal to have been sealed into a proven sector, which will
+	// be a function of sector size (among other things). For now, we pick a
+	// number sufficiently large as to ensure that a miner will have sufficient
+	// time to replicate and prove a 16MiB self deal-packed sector.
+	commitDelay := abi.ChainEpoch(2 * 60 * 24) // ~1 day into the future, assuming 30s block time
+
+	// A quantity of epochs for which the self-deal is valid.
+	duration := abi.ChainEpoch(2 * 60 * 24) // ~1 day
+
+	sdp := selfdeal.NewFixedDurationPolicy(api, commitDelay, duration)
+
 	s := &Sealing{
 		api:             api,
 		maddr:           maddr,
 		sb:              sb,
 		onSectorUpdated: onSectorUpdated,
-		selfDealPolicy:  sdp,
+		selfDealPolicy:  &sdp,
 	}
 
 	s.runCompleteWg.Add(1)

--- a/sealing/states.go
+++ b/sealing/states.go
@@ -1,7 +1,7 @@
 package sealing
 
 import (
-	sectorbuilder "github.com/filecoin-project/go-sectorbuilder"
+	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 	"github.com/filecoin-project/go-statemachine"
 	"github.com/filecoin-project/go-storage-miner/apis/node"
@@ -68,7 +68,7 @@ func (m *Sealing) handleUnsealed(ctx statemachine.Context, sector SectorInfo) er
 		}
 	}
 
-	tok, err := m.api.GetChainHead(ctx.Context())
+	tok, _, err := m.api.GetChainHead(ctx.Context())
 	if err != nil {
 		return xerrors.Errorf("failed to get chain head: %w", err)
 	}

--- a/sealing/states_failed.go
+++ b/sealing/states_failed.go
@@ -28,7 +28,7 @@ func failedCooldown(ctx statemachine.Context, sector SectorInfo) error {
 }
 
 func (m *Sealing) checkPreCommitted(ctx statemachine.Context, sector SectorInfo) ([]byte, bool, error) {
-	tok, err := m.api.GetChainHead(ctx.Context())
+	tok, _, err := m.api.GetChainHead(ctx.Context())
 	if err != nil {
 		return nil, false, xerrors.Errorf("failed to get chain head: %w", err)
 	}

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -16,7 +16,7 @@ import (
 type fakeNode struct {
 	checkPieces              func(ctx context.Context, sectorNum abi.SectorNumber, pieces []node.Piece) *node.CheckPiecesError
 	checkSealing             func(ctx context.Context, commD []byte, dealIDs []abi.DealID, ticket node.SealTicket) *node.CheckSealingError
-	getChainHead             func(ctx context.Context) (node.TipSetToken, error)
+	getChainHead             func(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error)
 	getMinerWorkerAddress    func(context.Context, node.TipSetToken) (address.Address, error)
 	getSealedCID             func(ctx context.Context, tok node.TipSetToken, sectorNum abi.SectorNumber) (cid.Cid, bool, error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError)
@@ -24,7 +24,7 @@ type fakeNode struct {
 	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.Piece) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
 	sendReportFaults         func(ctx context.Context, sectorNums ...abi.SectorNumber) (cid.Cid, error)
-	sendSelfDeals            func(context.Context, ...abi.PieceInfo) (cid.Cid, error)
+	sendSelfDeals            func(context.Context, abi.ChainEpoch, abi.ChainEpoch, ...abi.PieceInfo) (cid.Cid, error)
 	waitForProveCommitSector func(context.Context, cid.Cid) (exitCode uint8, err error)
 	waitForReportFaults      func(context.Context, cid.Cid) (uint8, error)
 	waitForSelfDeals         func(context.Context, cid.Cid) ([]abi.DealID, uint8, error)
@@ -39,8 +39,8 @@ func newFakeNode() *fakeNode {
 		checkSealing: func(ctx context.Context, commD []byte, dealIDs []abi.DealID, ticket node.SealTicket) *node.CheckSealingError {
 			return nil
 		},
-		getChainHead: func(ctx context.Context) (token node.TipSetToken, err error) {
-			return node.TipSetToken{1, 2, 3}, nil
+		getChainHead: func(ctx context.Context) (token node.TipSetToken, epoch abi.ChainEpoch, err error) {
+			return node.TipSetToken{1, 2, 3}, 42, nil
 		},
 		getMinerWorkerAddress: func(ctx context.Context, tok node.TipSetToken) (a address.Address, err error) {
 			return address.NewIDAddress(42)
@@ -72,7 +72,7 @@ func newFakeNode() *fakeNode {
 		sendReportFaults: func(ctx context.Context, sectorNumbers ...abi.SectorNumber) (i cid.Cid, e error) {
 			return createCidForTesting(42), nil
 		},
-		sendSelfDeals: func(ctx context.Context, info ...abi.PieceInfo) (c cid.Cid, err error) {
+		sendSelfDeals: func(ctx context.Context, start, end abi.ChainEpoch, info ...abi.PieceInfo) (c cid.Cid, err error) {
 			panic("by default, no self deals will be made")
 		},
 		waitForProveCommitSector: func(context.Context, cid.Cid) (exitCode uint8, err error) {
@@ -101,7 +101,7 @@ func (f *fakeNode) CheckSealing(ctx context.Context, commD []byte, dealIDs []abi
 	return f.checkSealing(ctx, commD, dealIDs, ticket)
 }
 
-func (f *fakeNode) GetChainHead(ctx context.Context) (node.TipSetToken, error) {
+func (f *fakeNode) GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error) {
 	return f.getChainHead(ctx)
 }
 
@@ -133,8 +133,8 @@ func (f *fakeNode) SendReportFaults(ctx context.Context, sectorNumbers ...abi.Se
 	return f.sendReportFaults(ctx, sectorNumbers...)
 }
 
-func (f *fakeNode) SendSelfDeals(ctx context.Context, pieces ...abi.PieceInfo) (cid.Cid, error) {
-	return f.sendSelfDeals(ctx, pieces...)
+func (f *fakeNode) SendSelfDeals(ctx context.Context, start, end abi.ChainEpoch, pieces ...abi.PieceInfo) (cid.Cid, error) {
+	return f.sendSelfDeals(ctx, start, end, pieces...)
 }
 
 func (f *fakeNode) WaitForProveCommitSector(ctx context.Context, msg cid.Cid) (exitCode uint8, err error) {

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -91,8 +91,8 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 			selfDealPieceSizes = append(selfDealPieceSizes, info[1].Size.Unpadded())
 
 			selfDealSchedule = selfdeal.Schedule{
-				StartEpoch:  start,
-				ExpiryEpoch: end,
+				StartEpoch: start,
+				EndEpoch:   end,
 			}
 
 			return createCidForTesting(42), nil
@@ -144,7 +144,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		assert.Equal(t, int(abi.UnpaddedPieceSize(254)), int(selfDealPieceSizes[0]))
 		assert.Equal(t, int(abi.UnpaddedPieceSize(508)), int(selfDealPieceSizes[1]))
 		assert.Greater(t, int(selfDealSchedule.StartEpoch), 0)
-		assert.Greater(t, int(selfDealSchedule.ExpiryEpoch), 0)
+		assert.Greater(t, int(selfDealSchedule.EndEpoch), 0)
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for sequence to complete: %s", getSequenceStatusFunc())
 	}

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -77,7 +77,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
 
-		n.sendSelfDeals = func(i context.Context, info ...abi.PieceInfo) (cid cid.Cid, e error) {
+		n.sendSelfDeals = func(i context.Context, start, end abi.ChainEpoch, info ...abi.PieceInfo) (cid cid.Cid, e error) {
 			selfDealPieceSizes = append(selfDealPieceSizes, info[0].Size.Unpadded())
 			selfDealPieceSizes = append(selfDealPieceSizes, info[1].Size.Unpadded())
 

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -32,9 +32,6 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 	maddr, err := address.NewIDAddress(55)
 	require.NoError(t, err)
 
-	api := newFakeNode()
-	sdp := selfdeal.NewFixedDurationPolicy(api, 10, 100)
-
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
 		then(sealing.Unsealed).
@@ -46,7 +43,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 		then(sealing.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(api, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(newFakeNode(), datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -105,8 +102,6 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		return n
 	}()
 
-	sdp := selfdeal.NewFixedDurationPolicy(fakeNode, 10, 100)
-
 	sb := &fakeSectorBuilder{}
 
 	// a sequence of sector state transitions we expect to observe
@@ -123,7 +118,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		then(sealing.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, maddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -167,8 +162,6 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 		return n
 	}()
 
-	sdp := selfdeal.NewFixedDurationPolicy(fakeNode, 10, 100)
-
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
 		then(sealing.Unsealed).
@@ -176,7 +169,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 		then(sealing.PreCommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -212,8 +205,6 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 		return n
 	}()
 
-	sdp := selfdeal.NewFixedDurationPolicy(fakeNode, 10, 100)
-
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
 		then(sealing.Unsealed).
@@ -223,7 +214,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 		then(sealing.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -259,8 +250,6 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 		return n
 	}()
 
-	sdp := selfdeal.NewFixedDurationPolicy(fakeNode, 10, 100)
-
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
 		then(sealing.Unsealed).
@@ -271,7 +260,7 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 		then(sealing.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {


### PR DESCRIPTION
## Why is this PR needed?

See [this thread](https://filecoinproject.slack.com/archives/CPLLE0ZQX/p1582073044104400) for some background. Basically, the go-storage-miner needs to choose self-deal time bounds.

## What's in this PR?

This PR adds a `SelfDealPolicy` interface and a single satisfying struct, `FixedDurationPolicy`. It uses values which that policy dispenses to create `SendSelfDeal` method calls with good start and end epochs.