### PR TITLE
compute sector pre-commit expiration

### DIFF
--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -23,7 +23,7 @@ type Interface interface {
 
 	// SendPreCommitSector publishes the miner's pre-commitment of a sector to a
 	// particular chain and returns the identity of the corresponding message.
-	SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket SealTicket, pieces ...PieceWithDealInfo) (cid.Cid, error)
+	SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...PieceWithDealInfo) (cid.Cid, error)
 
 	// SendProveCommitSector publishes the miner's seal proof and returns the
 	// the identity of the corresponding message.

--- a/apis/node/types.go
+++ b/apis/node/types.go
@@ -85,7 +85,7 @@ type DealInfo struct {
 	DealSchedule DealSchedule
 }
 
-// DealSchedule communicates the time interval of a stoage deal. The deal must
+// DealSchedule communicates the time interval of a storage deal. The deal must
 // appear in a sealed (proven) sector no later than StartEpoch, otherwise it
 // is invalid.
 type DealSchedule struct {

--- a/policies/precommit/basic.go
+++ b/policies/precommit/basic.go
@@ -1,0 +1,70 @@
+package precommit
+
+import (
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+)
+
+type Chain interface {
+	GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error)
+}
+
+// BasicPolicy satisfies precommit.Policy. It has two modes:
+//
+// Mode 1: The sector contains a non-zero quantity of pieces
+// Mode 2: The sector contains no pieces
+//
+// The BasicPolicy#Expiration method is given a slice of the pieces which the
+// miner has encoded into the sector, and from that slice picks either the
+// first or second mode.
+//
+// If we're in Mode 1: The pre-commit expiration epoch will be the maximum
+// deal end epoch of a piece in the sector.
+//
+// If we're in Mode 2: The pre-commit expiration epoch will be set to the
+// current epoch + the provided default duration.
+type BasicPolicy struct {
+	api Chain
+
+	duration abi.ChainEpoch
+}
+
+// NewBasicPolicy produces a BasicPolicy
+func NewBasicPolicy(api Chain, duration abi.ChainEpoch) BasicPolicy {
+	return BasicPolicy{
+		api:      api,
+		duration: duration,
+	}
+}
+
+// Expiration produces the pre-commit sector expiration epoch for an encoded
+// replica containing the provided enumeration of pieces and deals.
+func (p *BasicPolicy) Expiration(ctx context.Context, pdis ...node.PieceWithDealInfo) (abi.ChainEpoch, error) {
+	_, epoch, err := p.api.GetChainHead(ctx)
+	if err != nil {
+		return 0, nil
+	}
+
+	var end *abi.ChainEpoch
+
+	for _, p := range pdis {
+		if p.DealInfo.DealSchedule.EndEpoch < epoch {
+			log.Warnf("piece schedule %+v ended before current epoch %d", p, epoch)
+			continue
+		}
+
+		if end == nil || *end < p.DealInfo.DealSchedule.EndEpoch {
+			end = &p.DealInfo.DealSchedule.EndEpoch
+		}
+	}
+
+	if end == nil {
+		tmp := epoch + p.duration
+		end = &tmp
+	}
+
+	return *end, nil
+}

--- a/policies/precommit/interface.go
+++ b/policies/precommit/interface.go
@@ -1,0 +1,16 @@
+package precommit
+
+import (
+	"context"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	logging "github.com/ipfs/go-log"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+)
+
+var log = logging.Logger("precommit")
+
+type Policy interface {
+	Expiration(ctx context.Context, pdis ...node.PieceWithDealInfo) (abi.ChainEpoch, error)
+}

--- a/policies/precommit/test/basic_test.go
+++ b/policies/precommit/test/basic_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+
+	"github.com/filecoin-project/go-storage-miner/apis/node"
+	"github.com/filecoin-project/go-storage-miner/policies/precommit"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeChain struct {
+	h abi.ChainEpoch
+}
+
+func (f *fakeChain) GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error) {
+	return []byte{1, 2, 3}, f.h, nil
+}
+
+func TestBasicPolicyEmptySector(t *testing.T) {
+	policy := precommit.NewBasicPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 10)
+
+	exp, err := policy.Expiration(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 65, int(exp))
+}
+
+func TestBasicPolicyMostConstrictiveSchedule(t *testing.T) {
+	policy := precommit.NewBasicPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 100)
+
+	pieces := []node.PieceWithDealInfo{
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: node.DealInfo{
+				DealID: abi.DealID(42),
+				DealSchedule: node.DealSchedule{
+					StartEpoch: abi.ChainEpoch(70),
+					EndEpoch:   abi.ChainEpoch(75),
+				},
+			},
+		},
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: node.DealInfo{
+				DealID: abi.DealID(43),
+				DealSchedule: node.DealSchedule{
+					StartEpoch: abi.ChainEpoch(80),
+					EndEpoch:   abi.ChainEpoch(100),
+				},
+			},
+		},
+	}
+
+	exp, err := policy.Expiration(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, int(exp))
+}
+
+func TestBasicPolicyIgnoresExistingScheduleIfExpired(t *testing.T) {
+	policy := precommit.NewBasicPolicy(&fakeChain{
+		h: abi.ChainEpoch(55),
+	}, 100)
+
+	pieces := []node.PieceWithDealInfo{
+		{
+			Piece: abi.PieceInfo{
+				Size:     abi.PaddedPieceSize(1024),
+				PieceCID: commcid.ReplicaCommitmentV1ToCID([]byte{1, 2, 3}),
+			},
+			DealInfo: node.DealInfo{
+				DealID: abi.DealID(44),
+				DealSchedule: node.DealSchedule{
+					StartEpoch: abi.ChainEpoch(1),
+					EndEpoch:   abi.ChainEpoch(10),
+				},
+			},
+		},
+	}
+
+	exp, err := policy.Expiration(context.Background(), pieces...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 155, int(exp))
+}

--- a/policies/selfdeal/basic.go
+++ b/policies/selfdeal/basic.go
@@ -12,7 +12,7 @@ type Chain interface {
 	GetChainHead(ctx context.Context) (node.TipSetToken, abi.ChainEpoch, error)
 }
 
-// BasicPolicy is a SelfDealPolicy. It has two modes:
+// BasicPolicy satisfies selfdeal.Policy. It has two modes:
 //
 // Mode 1: The sector contains a non-zero quantity of client-provided pieces
 // Mode 2: The sector contains only self-deal pieces
@@ -24,7 +24,7 @@ type Chain interface {
 // If we're in Mode 1: The self-deal start and end-dates of the returned
 // DealSchedule will be set to the minimum and maximum start and end epoch
 // for pieces in the sector as long as at least one piece's deal contains both
-// start and end-dates which is in the future. Otherwise, fall back to Mode 2.
+// start and end-dates which is in the future.
 //
 // If we're in Mode 2: The self-deal start date will be set to the current
 // epoch + provingDelay. The self-deal end date will be set to the current epoch

--- a/policies/selfdeal/interface.go
+++ b/policies/selfdeal/interface.go
@@ -11,5 +11,5 @@ import (
 var log = logging.Logger("selfdeals")
 
 type Policy interface {
-	Schedule(ctx context.Context, pieces ...node.PieceWithOptionalDealInfo) (node.DealSchedule, error)
+	Schedule(ctx context.Context, pdis ...node.PieceWithOptionalDealInfo) (node.DealSchedule, error)
 }

--- a/sealing/states.go
+++ b/sealing/states.go
@@ -1,6 +1,7 @@
 package sealing
 
 import (
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	"github.com/filecoin-project/go-sectorbuilder"
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 	"github.com/filecoin-project/go-statemachine"
@@ -110,7 +111,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 		}
 	}
 
-	smsg, err := m.api.SendPreCommitSector(ctx.Context(), sector.SectorNum, sector.CommR, sector.Ticket, sector.Pieces...)
+	smsg, err := m.api.SendPreCommitSector(ctx.Context(), sector.SectorNum, commcid.ReplicaCommitmentV1ToCID(sector.CommR), abi.ChainEpoch(sector.Ticket.BlockHeight), 0, sector.Pieces...)
 	if err != nil {
 		return ctx.Send(SectorPreCommitFailed{xerrors.Errorf("failed to send pre-commit message: %w", err)})
 	}

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -21,7 +21,7 @@ type fakeNode struct {
 	getSealedCID             func(ctx context.Context, tok node.TipSetToken, sectorNum abi.SectorNumber) (cid.Cid, bool, error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError)
 	getSealTicket            func(context.Context, node.TipSetToken) (node.SealTicket, error)
-	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.PieceWithDealInfo) (cid.Cid, error)
+	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error)
 	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
 	sendReportFaults         func(ctx context.Context, sectorNums ...abi.SectorNumber) (cid.Cid, error)
 	sendSelfDeals            func(context.Context, abi.ChainEpoch, abi.ChainEpoch, ...abi.PieceInfo) (cid.Cid, error)
@@ -66,7 +66,7 @@ func newFakeNode() *fakeNode {
 				TicketBytes: []byte{1, 2, 3},
 			}, nil
 		},
-		sendPreCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
+		sendPreCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
 		sendReportFaults: func(ctx context.Context, sectorNumbers ...abi.SectorNumber) (i cid.Cid, e error) {
@@ -121,8 +121,8 @@ func (f *fakeNode) GetSealTicket(ctx context.Context, tok node.TipSetToken) (nod
 	return f.getSealTicket(ctx, tok)
 }
 
-func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
-	return f.sendPreCommitSector(ctx, sectorNum, commR, ticket, pieces...)
+func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
+	return f.sendPreCommitSector(ctx, sectorNum, sealedCID, sealEpoch, expiration, pieces...)
 }
 
 func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-storage-miner/policies/precommit"
+
 	"github.com/filecoin-project/go-storage-miner/policies/selfdeal"
 
 	"github.com/filecoin-project/go-address"
@@ -42,6 +44,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 
 	api := newFakeNode()
 	sdp := selfdeal.NewBasicPolicy(api, 10, 100)
+	pcp := precommit.NewBasicPolicy(api, 300)
 
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
@@ -54,7 +57,7 @@ func TestSuccessfulPieceSealingFlow(t *testing.T) {
 		then(sealing.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(api, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(api, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, &pcp, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -114,6 +117,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 	}()
 
 	sdp := selfdeal.NewBasicPolicy(fakeNode, 10, 100)
+	pcp := precommit.NewBasicPolicy(fakeNode, 300)
 
 	sb := &fakeSectorBuilder{}
 
@@ -131,7 +135,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 		then(sealing.Proving).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), sb, maddr, &sdp, &pcp, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -176,6 +180,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 	}()
 
 	sdp := selfdeal.NewBasicPolicy(fakeNode, 10, 100)
+	pcp := precommit.NewBasicPolicy(fakeNode, 300)
 
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
@@ -184,7 +189,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 		then(sealing.PreCommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, &pcp, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -221,6 +226,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 	}()
 
 	sdp := selfdeal.NewBasicPolicy(fakeNode, 10, 100)
+	pcp := precommit.NewBasicPolicy(fakeNode, 300)
 
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
@@ -231,7 +237,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 		then(sealing.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, &pcp, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {
@@ -268,6 +274,7 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 	}()
 
 	sdp := selfdeal.NewBasicPolicy(fakeNode, 10, 100)
+	pcp := precommit.NewBasicPolicy(fakeNode, 300)
 
 	// a sequence of sector state transitions we expect to observe
 	onSectorUpdatedFunc, getSequenceStatusFunc, doneCh := begin(t, DefaultSectorID, sealing.Packing).
@@ -279,7 +286,7 @@ func TestHandlesCommitSectorMessageWaitFailure(t *testing.T) {
 		then(sealing.CommitFailed).
 		end()
 
-	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, onSectorUpdatedFunc)
+	miner, err := storage.NewMinerWithOnSectorUpdated(fakeNode, datastore.NewMapDatastore(), &fakeSectorBuilder{}, maddr, &sdp, &pcp, onSectorUpdatedFunc)
 	require.NoError(t, err)
 
 	defer func() {

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -168,7 +168,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
 
-		n.sendPreCommitSector = func(ctx context.Context, sectorNum abi.SectorNumber, commR []byte, ticket node.SealTicket, pieces ...node.PieceWithDealInfo) (i cid.Cid, e error) {
+		n.sendPreCommitSector = func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
 			return cid.Undef, errors.New("expected error")
 		}
 


### PR DESCRIPTION
## Why does this PR exist?

The storage miner can't throw away its sector until all of the deals referencing that sector have expired (less that miner be penalized in some way). The pre-commit message includes an expiration field; go-storage-miner needs to send an appropriate expiration value back to the node.

## What's in this PR?

- use specs-actors types, when possible, in `SendPreCommitSector` method
- add expiration to `SendPreCommitSector` method
- add `precommit.BasicPolicy` struct and `precommit.Policy` interface