### PR TITLE
latest sectorbuilder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
-	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200305180647-701a23874a93
+	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d
 	github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9
 	github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:9
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200305180647-701a23874a93 h1:JLDP55K+g7imNpRjYTdfRqZfsoSF9FCbfm5OxK+bjQ8=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200305180647-701a23874a93/go.mod h1:PmE02y2T4vS8ukr1dxxLjgpHbaJQk2y3SMQvsPsJW28=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d h1:FRUaOxLQvPcyOrI1J/ZiGThohyoMimf5mpyH/ZF7b7o=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200306003553-541b1e74104d/go.mod h1:xAd/X905Ncgj8kkHsP2pmQUf6MQT2qJTDcOEfkwCjYc=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=


### PR DESCRIPTION
## What's in this PR?

This PR includes the following new commits from go-sectorbuilder into go-storage-miner:

```
commit 541b1e74104d314a5fbf3c0d437c8ff8089e34ad (HEAD -> master, origin/master, origin/HEAD)
Merge: fe772bf c9b6930
Author: Łukasz Magiera <magik6k@users.noreply.github.com>
Date:   Fri Mar 6 01:35:53 2020 +0100

    Merge pull request #81 from filecoin-project/fix/generate-epost

    Always pass valid Fr bytes

commit fe772bfb36dd1f02fff617ee7af182e7d8efc687
Author: Alex North <445306+anorth@users.noreply.github.com>
Date:   Thu Mar 5 16:31:40 2020 -0800

    GenerateUnsealedCID pads un-filled space in the sector with zero-pieces. (#86)

    This code is copied from https://github.com/filecoin-project/lotus/blob/47abf8e78e9056b5eda4444806f4063020578fd3/chain/vm/syscalls.go#L33.
```