### PR TITLE
avoid dup pieces by only returning new pieces

### DIFF
--- a/sealing/garbage.go
+++ b/sealing/garbage.go
@@ -37,7 +37,7 @@ func (m *Sealing) pledgeReader(size abi.UnpaddedPieceSize, parts uint64) io.Read
 // piece and deal metadata associated with that sector is returned.
 func (m *Sealing) pledgeSector(ctx context.Context, sectorNum abi.SectorNumber, existing []node.PieceWithDealInfo, fillerPieceSizes ...abi.UnpaddedPieceSize) ([]node.PieceWithDealInfo, error) {
 	if len(fillerPieceSizes) == 0 {
-		return existing, nil
+		return []node.PieceWithDealInfo{}, nil
 	}
 
 	log.Infof("Pledge %d, contains %+v", sectorNum, existing)
@@ -113,10 +113,7 @@ func (m *Sealing) pledgeSector(ctx context.Context, sectorNum abi.SectorNumber, 
 		existingSizes[idx] = existing[idx].Piece.Size.Unpadded()
 	}
 
-	out := make([]node.PieceWithDealInfo, len(existing))
-	for idx := range existing {
-		out[idx] = existing[idx]
-	}
+	out := []node.PieceWithDealInfo{}
 
 	for idx := range fillerPieceSizes {
 		pi, err := m.sb.AddPiece(ctx, fillerPieceSizes[idx], sectorNum, m.pledgeReader(fillerPieceSizes[idx], uint64(runtime.NumCPU())), existingSizes)

--- a/sealing/garbage.go
+++ b/sealing/garbage.go
@@ -34,7 +34,8 @@ func (m *Sealing) pledgeReader(size abi.UnpaddedPieceSize, parts uint64) io.Read
 // self-deals for those junk pieces. Junk pieces are written to the target
 // sector respecting alignment of the sector's existing pieces. After the sector
 // has been completely filled (with junk and/or client data), a slice of all
-// piece and deal metadata associated with that sector is returned.
+// newly added junk-piece and deal metadata associated with that sector is
+// returned.
 func (m *Sealing) pledgeSector(ctx context.Context, sectorNum abi.SectorNumber, existing []node.PieceWithDealInfo, fillerPieceSizes ...abi.UnpaddedPieceSize) ([]node.PieceWithDealInfo, error) {
 	if len(fillerPieceSizes) == 0 {
 		return []node.PieceWithDealInfo{}, nil


### PR DESCRIPTION
### Problem

PledgeSector is failing validation because it is adding too many pieces to the sector. The `garbage.pledgeSector` returns existing pieces plus any additional pieces. The mutation for this state actually appends pieces to the sector info rather than replacing them, so including the existing pieces duplicates the existing pieces.

### Solution

Only return new pieces from `garbage.pledgeSector`.