### PR TITLE
pass registered proof back to node

### DIFF
--- a/apis/node/interface.go
+++ b/apis/node/interface.go
@@ -23,11 +23,11 @@ type Interface interface {
 
 	// SendPreCommitSector publishes the miner's pre-commitment of a sector to a
 	// particular chain and returns the identity of the corresponding message.
-	SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...PieceWithDealInfo) (cid.Cid, error)
+	SendPreCommitSector(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...PieceWithDealInfo) (cid.Cid, error)
 
 	// SendProveCommitSector publishes the miner's seal proof and returns the
 	// the identity of the corresponding message.
-	SendProveCommitSector(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealids ...abi.DealID) (cid.Cid, error)
+	SendProveCommitSector(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, proof []byte, dealids ...abi.DealID) (cid.Cid, error)
 
 	// WaitForProveCommitSector blocks until the provided message is mined into
 	// a block.

--- a/sealing/states.go
+++ b/sealing/states.go
@@ -125,7 +125,7 @@ func (m *Sealing) handlePreCommitting(ctx statemachine.Context, sector SectorInf
 		return ctx.Send(SectorPreCommitFailed{xerrors.Errorf("failed to compute pre-commit expiration: %w", err)})
 	}
 
-	smsg, err := m.api.SendPreCommitSector(ctx.Context(), sector.SectorNum, commcid.ReplicaCommitmentV1ToCID(sector.CommR), abi.ChainEpoch(sector.Ticket.BlockHeight), expiration, sector.Pieces...)
+	smsg, err := m.api.SendPreCommitSector(ctx.Context(), m.sb.SealProofType(), sector.SectorNum, commcid.ReplicaCommitmentV1ToCID(sector.CommR), abi.ChainEpoch(sector.Ticket.BlockHeight), expiration, sector.Pieces...)
 	if err != nil {
 		return ctx.Send(SectorPreCommitFailed{xerrors.Errorf("failed to send pre-commit message: %w", err)})
 	}
@@ -180,7 +180,7 @@ func (m *Sealing) handleCommitting(ctx statemachine.Context, sector SectorInfo) 
 		return ctx.Send(SectorComputeProofFailed{xerrors.Errorf("computing seal proof failed: %w", err)})
 	}
 
-	smsg, err := m.api.SendProveCommitSector(ctx.Context(), sector.SectorNum, proof, sector.deals()...)
+	smsg, err := m.api.SendProveCommitSector(ctx.Context(), m.sb.SealProofType(), sector.SectorNum, proof, sector.deals()...)
 	if err != nil {
 		return ctx.Send(SectorCommitFailed{xerrors.Errorf("error sending prove commit sector: %w", err)})
 	}

--- a/test/fake_node.go
+++ b/test/fake_node.go
@@ -21,8 +21,8 @@ type fakeNode struct {
 	getSealedCID             func(ctx context.Context, tok node.TipSetToken, sectorNum abi.SectorNumber) (cid.Cid, bool, error)
 	getSealSeed              func(ctx context.Context, msg cid.Cid, interval uint64) (<-chan node.SealSeed, <-chan node.SeedInvalidated, <-chan node.FinalityReached, <-chan node.GetSealSeedError)
 	getSealTicket            func(context.Context, node.TipSetToken) (node.SealTicket, error)
-	sendPreCommitSector      func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error)
-	sendProveCommitSector    func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
+	sendPreCommitSector      func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error)
+	sendProveCommitSector    func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error)
 	sendReportFaults         func(ctx context.Context, sectorNums ...abi.SectorNumber) (cid.Cid, error)
 	sendSelfDeals            func(context.Context, abi.ChainEpoch, abi.ChainEpoch, ...abi.PieceInfo) (cid.Cid, error)
 	waitForProveCommitSector func(context.Context, cid.Cid) (exitCode uint8, err error)
@@ -66,7 +66,7 @@ func newFakeNode() *fakeNode {
 				TicketBytes: []byte{1, 2, 3},
 			}, nil
 		},
-		sendPreCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
+		sendPreCommitSector: func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
 		sendReportFaults: func(ctx context.Context, sectorNumbers ...abi.SectorNumber) (i cid.Cid, e error) {
@@ -87,7 +87,7 @@ func newFakeNode() *fakeNode {
 		walletHas: func(ctx context.Context, addr address.Address) (b bool, e error) {
 			return true, nil
 		},
-		sendProveCommitSector: func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
+		sendProveCommitSector: func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
 			return createCidForTesting(42), nil
 		},
 	}
@@ -121,12 +121,12 @@ func (f *fakeNode) GetSealTicket(ctx context.Context, tok node.TipSetToken) (nod
 	return f.getSealTicket(ctx, tok)
 }
 
-func (f *fakeNode) SendPreCommitSector(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
-	return f.sendPreCommitSector(ctx, sectorNum, sealedCID, sealEpoch, expiration, pieces...)
+func (f *fakeNode) SendPreCommitSector(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
+	return f.sendPreCommitSector(ctx, proofType, sectorNum, sealedCID, sealEpoch, expiration, pieces...)
 }
 
-func (f *fakeNode) SendProveCommitSector(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
-	return f.sendProveCommitSector(ctx, sectorNum, proof, dealIds...)
+func (f *fakeNode) SendProveCommitSector(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (cid.Cid, error) {
+	return f.sendProveCommitSector(ctx, proofType, sectorNum, proof, dealIds...)
 }
 
 func (f *fakeNode) SendReportFaults(ctx context.Context, sectorNumbers ...abi.SectorNumber) (cid.Cid, error) {

--- a/test/miner_test.go
+++ b/test/miner_test.go
@@ -113,7 +113,7 @@ func TestSealPieceCreatesSelfDealsToFillSector(t *testing.T) {
 			return []abi.DealID{abi.DealID(42), abi.DealID(43)}, 0, nil
 		}
 
-		n.sendPreCommitSector = func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (c cid.Cid, err error) {
+		n.sendPreCommitSector = func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (c cid.Cid, err error) {
 			for idx := range pieces {
 				preCommitSectorPieceSizes = append(preCommitSectorPieceSizes, pieces[idx].Piece.Size.Unpadded())
 			}
@@ -184,7 +184,7 @@ func TestHandlesPreCommitSectorSendFailed(t *testing.T) {
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
 
-		n.sendPreCommitSector = func(ctx context.Context, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
+		n.sendPreCommitSector = func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, sealedCID cid.Cid, sealEpoch, expiration abi.ChainEpoch, pieces ...node.PieceWithDealInfo) (cid.Cid, error) {
 			return cid.Undef, errors.New("expected error")
 		}
 
@@ -230,7 +230,7 @@ func TestHandlesProveCommitSectorMessageSendFailed(t *testing.T) {
 	fakeNode := func() *fakeNode {
 		n := newFakeNode()
 
-		n.sendProveCommitSector = func(ctx context.Context, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (i cid.Cid, e error) {
+		n.sendProveCommitSector = func(ctx context.Context, proofType abi.RegisteredProof, sectorNum abi.SectorNumber, proof []byte, dealIds ...abi.DealID) (i cid.Cid, e error) {
 			return cid.Undef, errors.New("expected error")
 		}
 


### PR DESCRIPTION
## Why does this PR exist?

To prevent ambiguity, the storage miner should send the `abi.RegisteredProof` used to pre-commit and commit back to the node.